### PR TITLE
Performance update

### DIFF
--- a/include/pairing_queue.hpp
+++ b/include/pairing_queue.hpp
@@ -18,16 +18,163 @@
 namespace pairing_queue {
 // Import std library components
 using std::numeric_limits;
+typedef time_t uint64_t;
+
+//! merge_pairs is the "magic" behind the pairing queue.
+//! when the queue pops, we must maintain the condition that
+//! `root->next = nullptr`.  we traverse the `newroot->next->(next->)*`
+//! linked list twice, first merging subsequent pairs, to produce a new
+//! linked list of half the size, and then merging the head of that list
+//! with its next until we're down to a single node
+template <typename N>
+inline N *_merge_pairs(N *a) {
+    N *r = nullptr;
+    do {
+        N *b = a->next;
+        if (b != nullptr) {
+            N *c = b->next;
+            b = _merge_roots_unsafe(a, b);
+            b->next = r;
+            r = b;
+            a = c;
+        } else {
+            a->next = r;
+            r = a;
+            break;
+        }
+    } while (a != nullptr);
+    a = r;
+    r = a->next;
+    while (r != nullptr) {
+        N *t = r->next;
+        a = _merge_roots_unsafe(a, r);
+        r = t;
+    }
+    return a;
+}
+
+//! merge_roots, assuming `other` is not null null, possibly invalidating
+//! the internal data structure (see source for details)
+template <typename N>
+inline N *_merge_roots_unsafe(N *a, N *b) {
+    // this unsafe version of merge_roots which
+    // * doesn't check for nullval
+    // * doesn't ensure that the returned node has next = nullval
+    minorminer_assert(a != nullptr);
+    minorminer_assert(b != nullptr);
+
+    if (*a < *b)
+        return a->merge_roots_unchecked(b);
+    else
+        return b->merge_roots_unchecked(a);
+}
 
 template <typename P, typename K>
 struct order_node {
+    time_t time;
+    K order;
     order_node<P, K> *next, *desc;
     P val;
-    uint64_t time;
-    K order;
-    inline bool operator<(const order_node<P, K> &b) const {
-        P v = b.val;
-        return (val < v) || ((val == v) && (order < b.order));
+    inline bool operator<(const order_node<P, K> &other) const {
+        return (val < other.val) || ((val == other.val) && (order < other.order));
+    }
+
+    // initialize this node and update its timestamp
+    inline void reset(time_t now) {
+        desc = nullptr;
+        next = this;
+        time = now;
+    }
+
+    // initialize this node
+    inline void reset() {
+        desc = nullptr;
+        next = this;
+    }
+
+    inline bool active() { return next != this; }
+
+    inline order_node<P, K> *merge_pairs() { return _merge_pairs(this); }
+
+    //! the basic operation of the pairing queue -- put `this` and `other`
+    //! into heap-order
+    inline order_node<P, K> *merge_roots(order_node<P, K> *other) {
+        if (other == nullptr) return this;
+        order_node<P, K> *c = _merge_roots_unsafe(this, other);
+        c->next = nullptr;
+        return c;
+    }
+
+    //! merge_roots, assuming `other` is not null and that `val` < `other->val`.
+    //!  may invalidate the internal data structure (see source for details)
+    inline order_node<P, K> *merge_roots_unchecked(order_node<P, K> *other) {
+        // this very unsafe version of self.merge_roots which
+        // * doesn't check for nullval
+        // * doesn't ensure that the returned node has next = nullval
+        // * doesn't check that this < other
+        minorminer_assert(other != nullptr);
+        minorminer_assert(*this < *other);
+
+        other->next = desc;
+        desc = other;
+        return this;
+    }
+};
+
+template <typename P>
+struct key_node {
+    P val;
+    time_t time;
+    key_node<P> *next, *desc, *prev;
+    inline bool operator<(const key_node<P> &other) const {
+        return (val < other.val) || ((val == other.val) && (this < &other));
+    }
+
+    // initialize this node and update its timestamp
+    inline void reset(time_t now) {
+        reset();
+        time = now;
+    }
+
+    // initialize this node
+    inline void reset() {
+        next = desc = nullptr;
+        prev = this;
+    }
+
+    inline bool active() { return next != this; }
+
+    inline key_node<P> *merge_pairs() {
+        key_node<P> *t = _merge_pairs(this);
+        t->prev = nullptr;
+        return t;
+    }
+
+    //! the basic operation of the pairing queue -- put `this` and `other`
+    //! into heap-order
+    inline key_node<P> *merge_roots(key_node<P> *other) {
+        if (other == nullptr) return this;
+        key_node<P> *c = _merge_roots_unsafe(this, other);
+        c->next = nullptr;
+        c->prev = nullptr;
+        return c;
+    }
+
+    //! merge_roots, assuming `other` is not null and that `val` < `other->val`.
+    //!  may invalidate the internal data structure (see source for details)
+    inline key_node<P> *merge_roots_unchecked(key_node<P> *other) {
+        // this very unsafe version of self.merge_roots which
+        // * doesn't check for nullval
+        // * doesn't ensure that the returned node has next = nullval
+        // * doesn't check that this < other
+        minorminer_assert(other != nullptr);
+        minorminer_assert(*this < *other);
+
+        key_node<P> *c = other->next = desc;
+        if (c != nullptr) c->prev = other;
+        other->prev = this;
+        desc = other;
+        return this;
     }
 };
 
@@ -42,7 +189,7 @@ class pairing_queue {
 
     N *root;
 
-    uint64_t now;
+    time_t now;
 
   public:
     //-------------
@@ -90,25 +237,10 @@ class pairing_queue {
     //! reset it (making it current)
     inline bool current(N *n) {
         if (n->time != now) {
-            reset(n);
+            n->reset(now);
             return false;
         }
         return true;
-    }
-
-    // blank out the links, except `next`, which points back to n indicating
-    // that this node is not currently in the queue
-    inline void reset(N *n) {
-        minorminer_assert(!empty(n));
-        n->desc = nullptr;
-        n->next = n;
-        n->time = now;
-    }
-
-    //! reset the node `n` and set its value to `v`
-    inline void reset(N *n, P v) {
-        reset(n);
-        n->val = v;
     }
 
   public:
@@ -118,11 +250,8 @@ class pairing_queue {
         if (empty()) return false;
 
         N *newroot = root->desc;
-        if (!empty(newroot)) {
-            newroot = merge_pairs(newroot);
-            newroot->next = nullptr;
-        }
-        reset(root);
+        if (newroot != nullptr) newroot = newroot->merge_pairs();
+        root->reset();
         root = newroot;
         return true;
     }
@@ -145,14 +274,14 @@ class pairing_queue {
   protected:
     //! protected variant of `set_value` using a node pointer
     inline void set_value(N *n, const P &v) {
-        minorminer_assert(!empty(n));
-        if (current(n) && n->next == n) {
+        minorminer_assert(n != nullptr);
+        if (current(n) && n->active()) {
             if (n->val != v) {
                 throw std::runtime_error("bad use of priority queue");
             }
         } else {
             n->val = v;
-            root = merge_roots(n, root);
+            root = n->merge_roots(root);
         }
     }
 
@@ -163,10 +292,10 @@ class pairing_queue {
 
   protected:
     inline bool check_insert(N *n, const P &v) {
-        minorminer_assert(!empty(n));
+        minorminer_assert(n != nullptr);
         if (!current(n)) {
             n->val = v;
-            root = merge_roots(n, root);
+            root = n->merge_roots(root);
             return true;
         } else {
             return false;
@@ -188,15 +317,15 @@ class pairing_queue {
     }
 
   public:
-    //! set the value associated with `k` to `v`, without making any other modifications
-    //! to the internal data structure
+    //! set the value associated with `k` to `v` without inserting / updating its position
+    //! in the queue -- this must only be used on keys that are not in the queue
     inline void set_value_unsafe(int k, const P &v) { set_value_unsafe(node(k), v); }
 
   protected:
     // protected variant of `set_value_unsafe` using a node pointer
     inline void set_value_unsafe(N *n, const P &v) {
         minorminer_assert(!empty(n));
-        current(n);
+        n->time = now;
         n->val = v;
     }
 
@@ -219,11 +348,7 @@ class pairing_queue {
 
   public:
     //! trueue this queue is empty
-    inline bool empty(void) const { return empty(root); }
-
-  protected:
-    //! protected variant of `empty`, can be used for non-root nodes
-    inline bool empty(N *n) const { return n == nullptr; }
+    inline bool empty(void) const { return root == nullptr; }
 
   public:
     //! return the stored value for `k`.  does not check that this value has
@@ -241,88 +366,6 @@ class pairing_queue {
     inline const N *const_node(int k) const {
         minorminer_assert(0 <= k && k < size());
         return nodes.data() + k;
-    }
-
-    //------------------------
-    // pairing-queue functions
-    //------------------------
-
-    //! INTERNAL USE ONLY most general merge_roots function.  assumes that
-    //! `a` is not null
-    inline N *merge_roots(N *a, N *b) {
-        // even this version of merge_roots is slightly unsafe -- we never call it with a null, so let's not check!
-        // * doesn't check for nullval
-        minorminer_assert(!empty(a));
-
-        if (empty(b)) return a;
-        N *c = merge_roots_unsafe(a, b);
-        return c;
-    }
-
-    //! INTERNAL USE ONLY merge_roots, assuming both `a` and `b` are not
-    //! null, possibly invalidating the internal data structure (see source
-    //! for details)
-    inline N *merge_roots_unsafe(N *a, N *b) {
-        // this unsafe version of merge_roots which
-        // * doesn't check for nullval
-        // * doesn't ensure that the returned node has next[a] = nullval
-        minorminer_assert(!empty(a));
-        minorminer_assert(!empty(b));
-
-        if (*a < *b)
-            return merge_roots_unchecked(a, b);
-        else
-            return merge_roots_unchecked(b, a);
-    }
-
-    //! INTERNAL USE ONLY merge_roots, assuming both `a` and `b` are not
-    //! null, and that `value(a)` < `value(b)`.  may invalidate the internal
-    //! data structure (see source for details)
-    inline N *merge_roots_unchecked(N *a, N *b) {
-        // this very unsafe version of self.merge_roots which
-        // * doesn't check for nullval
-        // * doesn't ensure that the returned node has next[a] = nullval
-        // * doesn't check that a < b
-        minorminer_assert(!empty(a));
-        minorminer_assert(!empty(b));
-        // minorminer_assert(a < b);
-
-        b->next = a->desc;
-        a->desc = b;
-        return a;
-    }
-
-    //! INTERNAL USE ONLY merge_pairs is the "magic" behind the pairing queue.
-    //! when the queue pops, we must maintain the condition that
-    //! `root->next = nullptr`.  we traverse the `newroot->next->(next->)*`
-    //! linked list twice, first merging subsequent pairs, to produce a new
-    //! linked list of half the size, and then merging the head of that list
-    //! with its next until we're down to a single node
-    inline N *merge_pairs(N *a) {
-        if (empty(a)) return nullptr;
-        N *r = nullptr;
-        do {
-            N *b = a->next;
-            if (!empty(b)) {
-                N *c = b->next;
-                b = merge_roots_unsafe(a, b);
-                b->next = r;
-                r = b;
-                a = c;
-            } else {
-                a->next = r;
-                r = a;
-                break;
-            }
-        } while (!empty(a));
-        a = r;
-        r = a->next;
-        while (!empty(r)) {
-            N *t = r->next;
-            a = merge_roots_unsafe(a, r);
-            r = t;
-        }
-        return a;
     }
 
     //----------------------
@@ -357,14 +400,6 @@ class pairing_queue {
     }
 };
 
-template <typename P>
-struct key_node {
-    key_node<P> *next, *desc, *prev;
-    P val;
-    uint64_t time;
-    inline bool operator<(const key_node<P> &b) const { return (val < b.val) || ((val == b.val) && (this < &b)); }
-};
-
 //! A priority queue based on a pairing heap, with fixed memory footprint and support for a decrease-key operation
 template <typename P, typename N = key_node<P>>
 class decrease_queue {
@@ -381,6 +416,9 @@ class decrease_queue {
   public:
     decrease_queue(int n) : nodes(n), root(nullptr), now(0) {}
 
+    //! Size of the queue
+    inline int size() const { return nodes.size(); }
+
     //! clear out this data structure or make it ready for the first time
     inline void reset() {
         root = nullptr;
@@ -389,41 +427,15 @@ class decrease_queue {
         }
     }
 
-    //! swap the memory of self with another pairing_queue
-    void swap(decrease_queue<P, N> &other) {
-        nodes.swap(other.nodes);
-        std::swap(root, other.root);
-        std::swap(now, other.now);
-    }
-
-    //! Size of the queue
-    inline int size() const { return nodes.size(); }
-
   protected:
-    // blank out the links, except `prev`, which points back to n indicating
-    // that this node is not currently in the queue
-    inline void reset(N *n) {
-        minorminer_assert(!empty(n));
-        n->desc = nullptr;
-        n->next = nullptr;
-        n->prev = n;
-        n->time = now;
-    }
-
     //! check if the node `n` is current (has `time=now`) and if not,
     //! reset it (making it current)
     inline bool current(N *n) {
         if (n->time != now) {
-            reset(n);
+            n->reset(now);
             return false;
         }
         return true;
-    }
-
-    //! reset the node `n` and set its value to `v`
-    inline void reset(N *n, P v) {
-        reset(n);
-        n->val = v;
     }
 
   public:
@@ -433,12 +445,8 @@ class decrease_queue {
         if (empty()) return false;
 
         N *newroot = root->desc;
-        if (!empty(newroot)) {
-            newroot = merge_pairs(newroot);
-            newroot->prev = nullptr;
-            newroot->next = nullptr;
-        }
-        reset(root);
+        if (newroot != nullptr) newroot = newroot->merge_pairs();
+        root->reset();
         root = newroot;
         return true;
     }
@@ -455,41 +463,19 @@ class decrease_queue {
     }
 
   public:
-    //! Decrease the value of k to v
-    //! NOTE: Assumes that v is lower than the current value of k
-    inline void decrease_value(int k, const P &v) { decrease_value(node(k), v); }
+    //! Set the value of k to v
+    //! Does nothing if v is already present.
+    inline bool check_insert(int k, const P &v) { return check_insert(node(k), v); }
 
   protected:
-    //! protected variant of `decrease_value` using a node pointer
-    inline void decrease_value(N *n, const P &v) {
-        minorminer_assert(!empty(n));
-        minorminer_assert(v < n->val);
-
-        n->val = v;
-        decrease(n);
-    }
-
-  public:
-    //! Decrease the value of k to v
-    //! Does nothing if v isn't actually a decrease.
-    inline bool check_decrease_value(int k, const P &v) { return check_decrease_value(node(k), v); }
-
-  protected:
-    //! protected variant of `check_decrease_value` using a node pointer
-    inline bool check_decrease_value(N *n, const P &v) {
-        minorminer_assert(!empty(n));
-        if (current(n)) {
-            if (v < n->val) {
-                n->val = v;
-                decrease(n);
-                return true;
-            } else {
-                return false;
-            }
-        } else {
+    inline bool check_insert(N *n, const P &v) {
+        minorminer_assert(n != nullptr);
+        if (!current(n)) {
             n->val = v;
-            root = merge_roots(n, root);
+            root = n->merge_roots(root);
             return true;
+        } else {
+            return false;
         }
     }
 
@@ -505,42 +491,6 @@ class decrease_queue {
             return n->val;
         else
             return max_P;
-    }
-
-  public:
-    //! set the value associated with `k` to `v`
-    inline void set_value(int k, const P &v) { set_value(node(k), v); }
-
-  protected:
-    //! protected variant of `set_value` using a node pointer
-    inline void set_value(N *n, const P &v) {
-        minorminer_assert(!empty(n));
-        if (current(n) && n->prev != n) {
-            if (v < n->val) {
-                n->val = v;
-                decrease(n);
-            } else if (n->val < v) {
-                n->val = v;
-                remove(n);
-                root = merge_roots(n, root);
-            }
-        } else {
-            n->val = v;
-            root = merge_roots(n, root);
-        }
-    }
-
-  public:
-    //! set the value associated with `k` to `v`, without making any other modifications
-    //! to the internal data structure
-    inline void set_value_unsafe(int k, const P &v) { set_value_unsafe(node(k), v); }
-
-  protected:
-    // protected variant of `set_value_unsafe` using a node pointer
-    inline void set_value_unsafe(N *n, const P &v) {
-        minorminer_assert(!empty(n));
-        current(n);
-        n->val = v;
     }
 
   public:
@@ -562,11 +512,7 @@ class decrease_queue {
 
   public:
     //! trueue this queue is empty
-    inline bool empty(void) const { return empty(root); }
-
-  protected:
-    //! protected variant of `empty`, can be used for non-root nodes
-    inline bool empty(N *n) const { return n == nullptr; }
+    inline bool empty(void) const { return root == nullptr; }
 
   public:
     //! return the stored value for `k`.  does not check that this value has
@@ -586,100 +532,81 @@ class decrease_queue {
         return nodes.data() + k;
     }
 
-    //! INTERNAL USE ONLY most general merge_roots function.  assumes that
-    //! `a` is not null
-    inline N *merge_roots(N *a, N *b) {
-        // even this version of merge_roots is slightly unsafe -- we never call it with a null, so let's not check!
-        // * doesn't check for nullval
-        minorminer_assert(!empty(a));
+  public:
+    //! Decrease the value of k to v
+    //! NOTE: Assumes that v is lower than the current value of k
+    inline void decrease_value(int k, const P &v) { decrease_value(node(k), v); }
 
-        if (empty(b)) return a;
-        N *c = merge_roots_unsafe(a, b);
-        c->prev = nullptr;
-        return c;
+  protected:
+    //! protected variant of `decrease_value` using a node pointer
+    inline void decrease_value(N *n, const P &v) {
+        minorminer_assert(n != nullptr);
+        minorminer_assert(v < n->val);
+
+        n->val = v;
+        decrease(n);
     }
 
-    //! INTERNAL USE ONLY merge_roots, assuming both `a` and `b` are not
-    //! null, possibly invalidating the internal data structure (see source
-    //! for details)
-    inline N *merge_roots_unsafe(N *a, N *b) {
-        // this unsafe version of merge_roots which
-        // * doesn't check for nullval
-        // * doesn't ensure that the returned node has prev[a] = nullval
-        minorminer_assert(!empty(a));
-        minorminer_assert(!empty(b));
+  public:
+    //! Decrease the value of k to v
+    //! Does nothing if v isn't actually a decrease.
+    inline bool check_decrease_value(int k, const P &v) { return check_decrease_value(node(k), v); }
 
-        if (*a < *b)
-            return merge_roots_unchecked(a, b);
-        else
-            return merge_roots_unchecked(b, a);
-    }
-
-    //! INTERNAL USE ONLY merge_roots, assuming both `a` and `b` are not
-    //! null, and that `value(a)` < `value(b)`.  may invalidate the internal
-    //! data structure (see source for details)
-    inline N *merge_roots_unchecked(N *a, N *b) {
-        // this very unsafe version of self.merge_roots which
-        // * doesn't check for nullval
-        // * doesn't ensure that the returned node has prev[a] = nullval
-        // * doesn't check that a < b
-        minorminer_assert(!empty(a));
-        minorminer_assert(!empty(b));
-        // minorminer_assert(a < b);
-
-        N *c = b->next = a->desc;
-        if (!empty(c)) c->prev = b;
-        b->prev = a;
-        a->desc = b;
-        return a;
-    }
-
-    //! INTERNAL USE ONLY merge_pairs is the "magic" behind the pairing queue.
-    //! when the queue pops, we must maintain the condition that
-    //! `root->next = nullptr`.  we traverse the `newroot->next->(next->)*`
-    //! linked list twice, first merging subsequent pairs, to produce a new
-    //! linked list of half the size, and then merging the head of that list
-    //! with its next until we're down to a single node
-    inline N *merge_pairs(N *a) {
-        if (empty(a)) return nullptr;
-        N *r = nullptr;
-        do {
-            N *b = a->next;
-            if (!empty(b)) {
-                N *c = b->next;
-                b = merge_roots_unsafe(a, b);
-                b->prev = r;
-                r = b;
-                a = c;
+  protected:
+    //! protected variant of `check_decrease_value` using a node pointer
+    inline bool check_decrease_value(N *n, const P &v) {
+        minorminer_assert(n != nullptr);
+        if (current(n)) {
+            if (v < n->val) {
+                n->val = v;
+                decrease(n);
+                return true;
             } else {
-                a->prev = r;
-                r = a;
-                break;
+                return false;
             }
-        } while (!empty(a));
-        a = r;
-        r = a->prev;
-        while (!empty(r)) {
-            N *t = r->prev;
-            a = merge_roots_unsafe(a, r);
-            r = t;
+        } else {
+            n->val = v;
+            root = n->merge_roots(root);
+            return true;
         }
-        return a;
+    }
+
+  public:
+    //! set the value associated with `k` to `v`
+    inline void set_value(int k, const P &v) { set_value(node(k), v); }
+
+  protected:
+    //! protected variant of `set_value` using a node pointer
+    inline void set_value(N *n, const P &v) {
+        minorminer_assert(n != nullptr);
+        if (current(n) && n->prev != n) {
+            if (v < n->val) {
+                n->val = v;
+                decrease(n);
+            } else if (n->val < v) {
+                n->val = v;
+                remove(n);
+                root = n->merge_roots(root);
+            }
+        } else {
+            n->val = v;
+            root = n->merge_roots(root);
+        }
     }
 
     //! INTERNAL USE ONLY removes node `a` from the pairing queue, assuming
     //! it is not the root
     inline void remove(N *a) {
-        minorminer_assert(!empty(a));
+        minorminer_assert(a != nullptr);
         N *b = a->prev;
         N *c = a->next;
-        minorminer_assert(!empty(b));
+        minorminer_assert(b != nullptr);
         if (b->desc == a)
             b->desc = c;
         else
             b->next = c;
 
-        if (!empty(c)) {
+        if (c != nullptr) {
             c->prev = b;
             a->next = nullptr;
         }
@@ -687,11 +614,11 @@ class decrease_queue {
 
     //! update the data structure to reflect a decrease in the value of `a`
     inline void decrease(N *a) {
-        minorminer_assert(!empty(a));
-        if (!empty(a->prev)) {
+        minorminer_assert(a != nullptr);
+        if (a->prev != nullptr) {
             minorminer_assert(a != root);  // theoretically, root is the only node with empty(prev)
             remove(a);
-            root = merge_roots(a, root);
+            root = a->merge_roots(root);
         }
     }
 };

--- a/include/pairing_queue.hpp
+++ b/include/pairing_queue.hpp
@@ -19,42 +19,20 @@ namespace pairing_queue {
 // Import std library components
 using std::numeric_limits;
 
-template <typename N>
-struct heap_link {
-    N *next, *desc, *prev;
-};
-
-template <typename P>
-struct value_field {
-    P val;
-    inline bool operator<(const value_field<P> &b) const { return (val < b.val) || ((val == b.val) && (this < &b)); }
-};
-
 template <typename P, typename K>
-struct order_field : value_field<P> {
-    using super = value_field<P>;
+struct order_node {
+    order_node<P, K> *next, *desc;
+    P val;
+    uint64_t time;
     K order;
-    inline bool operator<(const order_field<P, K> &b) const {
-        P v = static_cast<super>(b).val;
-        return (super::val < v) || ((super::val == v) && (order < b.order));
+    inline bool operator<(const order_node<P, K> &b) const {
+        P v = b.val;
+        return (val < v) || ((val == v) && (order < b.order));
     }
 };
 
-struct time_field {
-    int time;
-};
-
-template <typename P>
-struct plain_node : heap_link<plain_node<P>>, value_field<P> {};
-
-template <typename P>
-struct time_node : heap_link<time_node<P>>, value_field<P>, time_field {};
-
-template <typename P, typename K>
-struct order_node : heap_link<order_node<P, K>>, order_field<P, K>, time_field {};
-
-//! A priority queue based on a pairing heap, with fixed memory footprint and support for a decrease-key operation
-template <typename P, typename N = plain_node<P>>
+//! A priority queue based on a pairing heap, with fixed memory footprint
+template <typename P, typename K = uint64_t, typename N = order_node<P, K>>
 class pairing_queue {
   public:
     typedef P value_type;
@@ -64,25 +42,359 @@ class pairing_queue {
 
     N *root;
 
-  public:
-    pairing_queue(int n) : nodes(n), root(nullptr) {}
+    uint64_t now;
 
-    //! swap the memory of self with another pairing_queue
-    void swap(pairing_queue<P, N> &other) {
-        nodes.swap(other.nodes);
-        std::swap(root, other.root);
+  public:
+    //-------------
+    // constructors
+    //-------------
+
+    //! this constructor calls `rng()` for each of `n` nodes,
+    //! storing a value for tie-breaking purposes.
+    template <typename R>
+    pairing_queue(int n, R &rng) : nodes(n), root(nullptr), now(0) {
+        reorder(rng);
     }
 
-    //! Reset the queue and fill the values with a default
-    inline void reset_fill(const P v) {
+    //! this constructor is generally bad idea, but tie-breaking is still
+    //! deterministic
+    pairing_queue(int n) : nodes(n), root(nullptr), now(0) {
+        int k = 0;
+        for (auto &n : nodes) n.order = k++;
+    }
+
+    //-----------------------------------
+    // priority-queue interface functions
+    //-----------------------------------
+
+    //! swap the memory of self with another pairing_queue
+    void swap(pairing_queue<P, K, N> &other) {
+        nodes.swap(other.nodes);
+        std::swap(root, other.root);
+        std::swap(now, other.now);
+    }
+
+    //! Size of the queue
+    inline int size() const { return nodes.size(); }
+
+    //! clear out this data structure or make it ready for the first time
+    inline void reset() {
         root = nullptr;
-        for (auto &n : nodes) {
-            reset(&n, v);
+        if (!now++) {
+            for (auto &n : nodes) n.time = 0;
         }
     }
 
-    //! Reset the queue and set the default to the maximum value
-    inline void reset() { reset_fill(max_P); }
+  protected:
+    //! check if the node `n` is current (has `time=now`) and if not,
+    //! reset it (making it current)
+    inline bool current(N *n) {
+        if (n->time != now) {
+            reset(n);
+            return false;
+        }
+        return true;
+    }
+
+    // blank out the links, except `next`, which points back to n indicating
+    // that this node is not currently in the queue
+    inline void reset(N *n) {
+        minorminer_assert(!empty(n));
+        n->desc = nullptr;
+        n->next = n;
+        n->time = now;
+    }
+
+    //! reset the node `n` and set its value to `v`
+    inline void reset(N *n, P v) {
+        reset(n);
+        n->val = v;
+    }
+
+  public:
+    //! Remove the minimum value
+    //! return true if any change is made
+    inline bool delete_min() {
+        if (empty()) return false;
+
+        N *newroot = root->desc;
+        if (!empty(newroot)) {
+            newroot = merge_pairs(newroot);
+            newroot->next = nullptr;
+        }
+        reset(root);
+        root = newroot;
+        return true;
+    }
+
+    //! Remove and return (in args) the minimum key, value pair
+    inline bool pop_min(int &key, P &value) {
+        if (empty()) {
+            return false;
+        }
+        key = min_key();
+        value = min_value();
+        delete_min();
+        return true;
+    }
+
+  public:
+    //! set the value associated with `k` to `v`
+    inline void set_value(int k, const P &v) { set_value(node(k), v); }
+
+  protected:
+    //! protected variant of `set_value` using a node pointer
+    inline void set_value(N *n, const P &v) {
+        minorminer_assert(!empty(n));
+        if (current(n) && n->next == n) {
+            if (n->val != v) {
+                throw std::runtime_error("bad use of priority queue");
+            }
+        } else {
+            n->val = v;
+            root = merge_roots(n, root);
+        }
+    }
+
+  public:
+    //! Set the value of k to v
+    //! Does nothing if v is already present.
+    inline bool check_insert(int k, const P &v) { return check_insert(node(k), v); }
+
+  protected:
+    inline bool check_insert(N *n, const P &v) {
+        minorminer_assert(!empty(n));
+        if (!current(n)) {
+            n->val = v;
+            root = merge_roots(n, root);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+  public:
+    //! Safe value getter.  If `k` doesn't have a value (safely or unsafely set)
+    //! since the last reset, returns numeric_limits<P>::max().  This works even
+    //! after `k` has been popped.
+    inline P get_value(int k) const { return get_value(const_node(k)); }
+
+  protected:
+    inline P get_value(const N *n) const {
+        if (n->time == now)
+            return n->val;
+        else
+            return max_P;
+    }
+
+  public:
+    //! set the value associated with `k` to `v`, without making any other modifications
+    //! to the internal data structure
+    inline void set_value_unsafe(int k, const P &v) { set_value_unsafe(node(k), v); }
+
+  protected:
+    // protected variant of `set_value_unsafe` using a node pointer
+    inline void set_value_unsafe(N *n, const P &v) {
+        minorminer_assert(!empty(n));
+        current(n);
+        n->val = v;
+    }
+
+  public:
+    //! get the current minimum value (assumes `!empty()`)
+    inline P min_value() const {
+        minorminer_assert(!empty());
+        return root->val;
+    }
+
+    //! get the current minimum-value key (assumes `!empty()`)
+    inline int min_key() const {
+        minorminer_assert(!empty());
+        return key(root);
+    }
+
+  protected:
+    //! get the key of a node
+    inline int key(N *n) const { return n - nodes.data(); }
+
+  public:
+    //! trueue this queue is empty
+    inline bool empty(void) const { return empty(root); }
+
+  protected:
+    //! protected variant of `empty`, can be used for non-root nodes
+    inline bool empty(N *n) const { return n == nullptr; }
+
+  public:
+    //! return the stored value for `k`.  does not check that this value has
+    //! been initialized or re-initialized since the last reset
+    inline P value(int k) const { return const_node(k)->val; }
+
+  protected:
+    //! node pointer accessor
+    inline N *node(int k) {
+        minorminer_assert(0 <= k && k < size());
+        return nodes.data() + k;
+    }
+
+    //! const node pointer accessor
+    inline const N *const_node(int k) const {
+        minorminer_assert(0 <= k && k < size());
+        return nodes.data() + k;
+    }
+
+    //------------------------
+    // pairing-queue functions
+    //------------------------
+
+    //! INTERNAL USE ONLY most general merge_roots function.  assumes that
+    //! `a` is not null
+    inline N *merge_roots(N *a, N *b) {
+        // even this version of merge_roots is slightly unsafe -- we never call it with a null, so let's not check!
+        // * doesn't check for nullval
+        minorminer_assert(!empty(a));
+
+        if (empty(b)) return a;
+        N *c = merge_roots_unsafe(a, b);
+        return c;
+    }
+
+    //! INTERNAL USE ONLY merge_roots, assuming both `a` and `b` are not
+    //! null, possibly invalidating the internal data structure (see source
+    //! for details)
+    inline N *merge_roots_unsafe(N *a, N *b) {
+        // this unsafe version of merge_roots which
+        // * doesn't check for nullval
+        // * doesn't ensure that the returned node has next[a] = nullval
+        minorminer_assert(!empty(a));
+        minorminer_assert(!empty(b));
+
+        if (*a < *b)
+            return merge_roots_unchecked(a, b);
+        else
+            return merge_roots_unchecked(b, a);
+    }
+
+    //! INTERNAL USE ONLY merge_roots, assuming both `a` and `b` are not
+    //! null, and that `value(a)` < `value(b)`.  may invalidate the internal
+    //! data structure (see source for details)
+    inline N *merge_roots_unchecked(N *a, N *b) {
+        // this very unsafe version of self.merge_roots which
+        // * doesn't check for nullval
+        // * doesn't ensure that the returned node has next[a] = nullval
+        // * doesn't check that a < b
+        minorminer_assert(!empty(a));
+        minorminer_assert(!empty(b));
+        // minorminer_assert(a < b);
+
+        b->next = a->desc;
+        a->desc = b;
+        return a;
+    }
+
+    //! INTERNAL USE ONLY merge_pairs is the "magic" behind the pairing queue.
+    //! when the queue pops, we must maintain the condition that
+    //! `root->next = nullptr`.  we traverse the `newroot->next->(next->)*`
+    //! linked list twice, first merging subsequent pairs, to produce a new
+    //! linked list of half the size, and then merging the head of that list
+    //! with its next until we're down to a single node
+    inline N *merge_pairs(N *a) {
+        if (empty(a)) return nullptr;
+        N *r = nullptr;
+        do {
+            N *b = a->next;
+            if (!empty(b)) {
+                N *c = b->next;
+                b = merge_roots_unsafe(a, b);
+                b->next = r;
+                r = b;
+                a = c;
+            } else {
+                a->next = r;
+                r = a;
+                break;
+            }
+        } while (!empty(a));
+        a = r;
+        r = a->next;
+        while (!empty(r)) {
+            N *t = r->next;
+            a = merge_roots_unsafe(a, r);
+            r = t;
+        }
+        return a;
+    }
+
+    //----------------------
+    // tie-breaker functions
+    //----------------------
+  protected:
+    //! updates the tie-breaker for `n`
+    template <typename R>
+    inline void reorder(N *n, R &rng, int size, int ord) {
+        n->order = rng() * size + ord;
+    }
+
+    //! fetch the tie-breaker for `n`
+    inline K get_order(int k) const { return const_node(k)->order; }
+
+  public:
+    //! refresh the tie-breaking with a new set of random values
+    template <typename R>
+    inline void reorder(R &rng) {
+        int size = nodes.size();
+        for (int k = size; k--;) {
+            reorder(node(k), rng, size, k);
+        }
+    }
+
+    //! duplicate the tie-breaking of another pairing_queue
+    inline void reorder_copy(const pairing_queue<P, K, N> &other) {
+        int size = nodes.size();
+        for (int k = size; k--;) {
+            node(k)->order = other.get_order(k);
+        }
+    }
+};
+
+template <typename P>
+struct key_node {
+    key_node<P> *next, *desc, *prev;
+    P val;
+    uint64_t time;
+    inline bool operator<(const key_node<P> &b) const { return (val < b.val) || ((val == b.val) && (this < &b)); }
+};
+
+//! A priority queue based on a pairing heap, with fixed memory footprint and support for a decrease-key operation
+template <typename P, typename N = key_node<P>>
+class decrease_queue {
+  public:
+    typedef P value_type;
+
+  protected:
+    std::vector<N> nodes;
+
+    N *root;
+
+    uint64_t now;
+
+  public:
+    decrease_queue(int n) : nodes(n), root(nullptr), now(0) {}
+
+    //! clear out this data structure or make it ready for the first time
+    inline void reset() {
+        root = nullptr;
+        if (!now++) {
+            for (auto &n : nodes) n.time = 0;
+        }
+    }
+
+    //! swap the memory of self with another pairing_queue
+    void swap(decrease_queue<P, N> &other) {
+        nodes.swap(other.nodes);
+        std::swap(root, other.root);
+        std::swap(now, other.now);
+    }
 
     //! Size of the queue
     inline int size() const { return nodes.size(); }
@@ -95,6 +407,17 @@ class pairing_queue {
         n->desc = nullptr;
         n->next = nullptr;
         n->prev = n;
+        n->time = now;
+    }
+
+    //! check if the node `n` is current (has `time=now`) and if not,
+    //! reset it (making it current)
+    inline bool current(N *n) {
+        if (n->time != now) {
+            reset(n);
+            return false;
+        }
+        return true;
     }
 
     //! reset the node `n` and set its value to `v`
@@ -155,13 +478,33 @@ class pairing_queue {
     //! protected variant of `check_decrease_value` using a node pointer
     inline bool check_decrease_value(N *n, const P &v) {
         minorminer_assert(!empty(n));
-        if (v < n->val) {
-            n->val = v;
-            decrease(n);
-            return true;
+        if (current(n)) {
+            if (v < n->val) {
+                n->val = v;
+                decrease(n);
+                return true;
+            } else {
+                return false;
+            }
         } else {
-            return false;
+            n->val = v;
+            root = merge_roots(n, root);
+            return true;
         }
+    }
+
+  public:
+    //! Safe value getter.  If `k` doesn't have a value (safely or unsafely set)
+    //! since the last reset, returns numeric_limits<P>::max().  This works even
+    //! after `k` has been popped.
+    inline P get_value(int k) const { return get_value(const_node(k)); }
+
+  protected:
+    inline P get_value(const N *n) const {
+        if (n->time == now)
+            return n->val;
+        else
+            return max_P;
     }
 
   public:
@@ -172,15 +515,17 @@ class pairing_queue {
     //! protected variant of `set_value` using a node pointer
     inline void set_value(N *n, const P &v) {
         minorminer_assert(!empty(n));
-        if (n->prev == n) {
+        if (current(n) && n->prev != n) {
+            if (v < n->val) {
+                n->val = v;
+                decrease(n);
+            } else if (n->val < v) {
+                n->val = v;
+                remove(n);
+                root = merge_roots(n, root);
+            }
+        } else {
             n->val = v;
-            root = merge_roots(n, root);
-        } else if (v < n->val) {
-            n->val = v;
-            decrease(n);
-        } else if (n->val < v) {
-            n->val = v;
-            remove(n);
             root = merge_roots(n, root);
         }
     }
@@ -194,6 +539,7 @@ class pairing_queue {
     // protected variant of `set_value_unsafe` using a node pointer
     inline void set_value_unsafe(N *n, const P &v) {
         minorminer_assert(!empty(n));
+        current(n);
         n->val = v;
     }
 
@@ -346,148 +692,6 @@ class pairing_queue {
             minorminer_assert(a != root);  // theoretically, root is the only node with empty(prev)
             remove(a);
             root = merge_roots(a, root);
-        }
-    }
-};
-
-//! This is a specialization of the pairing_queue that has a constant time
-//! reset method, at the expense of an extra check when values are set or updated.
-template <typename P, typename N = time_node<P>>
-class pairing_queue_fast_reset : public pairing_queue<P, N> {
-    using super = pairing_queue<P, N>;
-
-  protected:
-    int now;
-
-    //! reset the node `n` and make it current
-    inline void reset(N *n) {
-        super::reset(n);
-        n->time = now;
-    }
-
-    //! check if the node `n` is current (has `time=now`) and if not,
-    //! reset it (making it current)
-    inline bool current(N *n) {
-        if (n->time != now) {
-            reset(n);
-            return false;
-        }
-        return true;
-    }
-
-  public:
-    pairing_queue_fast_reset(int n) : super(n), now(0) {}
-
-    //! swap the memory of self with another pairing_queue_fast_reset
-    void swap(pairing_queue_fast_reset<P, N> &other) {
-        super::swap(other);
-        std::swap(now, other.now);
-    }
-
-    //! clear out this data structure or make it ready for the first time
-    inline void reset() {
-        super::root = nullptr;
-        if (!now++) {
-            for (auto &n : super::nodes) n.time = 0;
-        }
-    }
-
-    //! set the value associated with `k` to `v`, without making any other modifications
-    //! to the internal data structure
-    inline void set_value_unsafe(int k, const P &v) {
-        auto n = super::node(k);
-        current(n);
-        super::set_value_unsafe(n, v);
-    }
-
-    //! set the value associated with `k` to `v`
-    inline void set_value(int k, const P &v) {
-        auto n = super::node(k);
-        if (current(n))
-            super::set_value(n, v);
-        else {
-            n->val = v;
-            super::root = super::merge_roots(n, super::root);
-        }
-    }
-
-    //! Decrease the value of k to v
-    //! Does nothing if v isn't actually a decrease.
-    inline bool check_decrease_value(int k, const P &v) {
-        auto n = super::node(k);
-        if (current(n))
-            return super::check_decrease_value(n, v);
-        else {
-            super::set_value(n, v);
-            return true;
-        }
-    }
-
-    //! Safe value getter.  If `k` doesn't have a value (safely or unsafely set)
-    //! since the last reset, returns numeric_limits<P>::max().  This works even
-    //! after `k` has been popped.
-    inline P get_value(int k) const {
-        auto n = super::const_node(k);
-        if (n->time == now)
-            return n->val;
-        else
-            return max_P;
-    }
-};
-
-//! This is a specialization of the pairing_queue_fast_reset which implements
-//! random tie-breaking.  the random tie-breaking is based on randomized
-//! fields which are not changed on `reset()`.  that means that the randomization
-//! is deterministic for the sake of using this as a priority queue, but
-//! only properly "random" if a `reorder` is called with every `reset`.
-//! for our purposes, it is sufficient (and somewhat preferable) to initialize
-//! a number of these queues with an RNG and occasionally/randomly swap which
-//! queue is used for what
-template <typename P, typename K = uint64_t, typename N = order_node<P, K>>
-class pairing_queue_fast_reset_rtb : public pairing_queue_fast_reset<P, N> {
-    using super = pairing_queue_fast_reset<P, N>;
-    using grand = pairing_queue<P, N>;
-
-  public:
-    //! this constructor calls `rng()` for each of `n` nodes,
-    //! storing a value for tie-breaking purposes.
-    template <typename R>
-    pairing_queue_fast_reset_rtb(int n, R &rng) : super(n) {
-        reorder(rng);
-    }
-
-    //! this constructor is generally bad idea, but tie-breaking is still
-    //! deterministic
-    pairing_queue_fast_reset_rtb(int n) : super(n) {
-        int k = 0;
-        for (auto &n : grand::nodes) n.order = k++;
-    }
-
-  protected:
-    //! updates the tie-breaker for `n`
-    template <typename R>
-    inline void reorder(N *n, R &rng, int size, int ord) {
-        n->order = rng() * size + ord;
-    }
-
-    //! fetch the tie-breaker for `n`
-    inline K get_order(int k) const { return grand::const_node(k)->order; }
-
-  public:
-    //! refresh the tie-breaking with a new set of random values
-    template <typename R>
-    inline void reorder(R &rng) {
-        int size = grand::nodes.size();
-        for (int k = size; k--;) {
-            reorder(grand::node(k), rng, size, k);
-        }
-    }
-
-    //! duplicate the tie-breaking of another pairing_queue_fast_reset_rtb
-    inline void reorder_copy(const pairing_queue_fast_reset_rtb<P, K, N> &other) {
-        int size = grand::nodes.size();
-        for (int k = size; k--;) {
-            grand::node(k)->order = other.get_order(k);
         }
     }
 };

--- a/include/pathfinder.hpp
+++ b/include/pathfinder.hpp
@@ -427,7 +427,7 @@ class pathfinder_base : public pathfinder_public_interface {
                 for (auto &p : ep.qubit_neighbors(q)) {
                     if (std::is_same<behavior_tag, embedded_tag>::value) {
                         if (emb.weight(p) == 0) {
-                            pq.set_value(p, 1);
+                            pq.check_insert(p, 1);
                             parent[p] = q;
                             visited[p] = 1;
                         } else {
@@ -436,7 +436,7 @@ class pathfinder_base : public pathfinder_public_interface {
                     }
                     if (std::is_same<behavior_tag, default_tag>::value) {
                         if (emb.weight(p) < ep.weight_bound) {
-                            pq.set_value(p, qubit_weight[p]);
+                            pq.check_insert(p, 1);
                             parent[p] = q;
                             visited[p] = 1;
                         } else {
@@ -447,7 +447,7 @@ class pathfinder_base : public pathfinder_public_interface {
             }
         } else {
             for (auto &q : emb.get_chain(v)) {
-                pq.set_value(q, 0);
+                pq.check_insert(q, 1);
                 parent[q] = -1;
                 visited[q] = 1;
             }

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -33,9 +33,8 @@ using distance_t = long long int;
 constexpr distance_t max_distance = numeric_limits<distance_t>::max();
 using RANDOM = fastrng;
 using clock = std::chrono::high_resolution_clock;
-using pairing_queue::pairing_queue_fast_reset;
-using distance_queue = pairing_queue::pairing_queue_fast_reset_rtb<distance_t>;
-using int_queue = pairing_queue::pairing_queue_fast_reset<int64_t>;
+using distance_queue = pairing_queue::pairing_queue<distance_t>;
+using int_queue = pairing_queue::decrease_queue<int64_t>;
 
 //! Interface for communication between the library and various bindings.
 //!

--- a/python/minorminer.pxi
+++ b/python/minorminer.pxi
@@ -43,7 +43,7 @@ cdef extern from "../include/graph.hpp" namespace "graph":
 
 cdef extern from "../include/pairing_queue.hpp" namespace "pairing_queue":
     cppclass pairing_queue
-    cppclass pairing_queue_fast_reset
+    cppclass decrease_queue
 
 cdef extern from "../include/pathfinder.hpp" namespace "find_embedding":
     cppclass pathfinder_public_interface

--- a/tests/test_pairing_queue.cpp
+++ b/tests/test_pairing_queue.cpp
@@ -615,17 +615,16 @@ TEST(decrease_queue, increase) {
 }
 
 // Fill a queue with random values, ensure sortedness.
-TEST(decrease_queue, setvalue_vs_sort) {
+TEST(decrease_queue, checkinsert_vs_sort) {
     std::random_device rng;
     vector<unsigned int> values(10);
     pairing_queue::decrease_queue<unsigned int> queue(10);
     queue.reset();
 
-    for (int i = 0; i < 500; i++) {
+    for (int i = 0; i < 20; i++) {
         unsigned int v = rng();
         int k = i % 10;
-        queue.set_value(k, v);
-        values[k] = v;
+        if (queue.check_insert(k, v)) values[k] = v;
     }
 
     vector<int> keys;
@@ -643,28 +642,60 @@ TEST(decrease_queue, setvalue_vs_sort) {
 }
 
 // Fill a queue with random values, ensure sortedness.
+TEST(decrease_queue, setvalue_vs_sort) {
+    std::random_device rng;
+    vector<unsigned int> values(10);
+    pairing_queue::decrease_queue<unsigned int> queue(10);
+    for (int j = 500; j--;) {
+        queue.reset();
+
+        for (int i = 0; i < 500; i++) {
+            unsigned int v = rng();
+            int k = i % 10;
+            queue.set_value(k, v);
+            values[k] = v;
+        }
+
+        vector<int> keys;
+        unsigned int last_v;
+        for (int i = 0; i < 10; i++) {
+            int k = queue.min_key();
+            unsigned int v = queue.min_value();
+            queue.delete_min();
+            keys.push_back(k);
+            EXPECT_EQ(v, values[k]);
+            if (i) EXPECT_LE(last_v, v);
+            last_v = v;
+        }
+        EXPECT_TRUE(queue.empty());
+    }
+}
+
+// Fill a queue with random values, ensure sortedness.
 TEST(decrease_queue, checkdecrease_vs_sort) {
     std::random_device rng;
     vector<unsigned int> values(10);
     pairing_queue::decrease_queue<unsigned int> queue(10);
-    queue.reset();
+    for (int j = 500; j--;) {
+        queue.reset();
 
-    for (int i = 0; i < 500; i++) {
-        unsigned int v = rng();
-        int k = i % 10;
-        if (queue.check_decrease_value(k, v)) values[k] = v;
-    }
+        for (int i = 0; i < 500; i++) {
+            unsigned int v = rng();
+            int k = i % 10;
+            if (queue.check_decrease_value(k, v)) values[k] = v;
+        }
 
-    vector<int> keys;
-    unsigned int last_v;
-    for (int i = 0; i < 10; i++) {
-        int k = queue.min_key();
-        unsigned int v = queue.min_value();
-        queue.delete_min();
-        keys.push_back(k);
-        EXPECT_EQ(v, values[k]);
-        if (i) EXPECT_LE(last_v, v);
-        last_v = v;
+        vector<int> keys;
+        unsigned int last_v;
+        for (int i = 0; i < 10; i++) {
+            int k = queue.min_key();
+            unsigned int v = queue.min_value();
+            queue.delete_min();
+            keys.push_back(k);
+            EXPECT_EQ(v, values[k]);
+            if (i) EXPECT_LE(last_v, v);
+            last_v = v;
+        }
+        EXPECT_TRUE(queue.empty());
     }
-    EXPECT_TRUE(queue.empty());
 }

--- a/tests/test_pairing_queue.cpp
+++ b/tests/test_pairing_queue.cpp
@@ -1,5 +1,8 @@
-#include "graph.hpp"
+#include <random>
+#include <vector>
 #include "gtest/gtest.h"
+#include "pairing_queue.hpp"
+using std::vector;
 
 // Construct an empty queue
 TEST(pairing_queue, construction) {
@@ -29,7 +32,7 @@ TEST(pairing_queue, insert_single) {
     pairing_queue::pairing_queue<int> queue(10);
     queue.reset();
 
-    queue.set_value(5, 0);
+    queue.check_insert(5, 0);
 
     int key, value;
     auto has_result = queue.pop_min(key, value);
@@ -43,8 +46,8 @@ TEST(pairing_queue, insert_two) {
     pairing_queue::pairing_queue<int> queue(10);
     queue.reset();
 
-    queue.set_value(5, 10);
-    queue.set_value(8, 6);
+    queue.check_insert(5, 10);
+    queue.check_insert(8, 6);
 
     int key, value;
     auto has_result = queue.pop_min(key, value);
@@ -66,7 +69,7 @@ TEST(pairing_queue, insert_reverse) {
     queue.reset();
 
     for (int ii = 0; ii < 10; ii++) {
-        queue.set_value(ii, 10 - ii);
+        queue.check_insert(ii, 10 - ii);
     }
 
     for (int ii = 0; ii < 9; ii++) {
@@ -96,126 +99,7 @@ TEST(pairing_queue, insert_forward) {
     queue.reset();
 
     for (int ii = 0; ii < 10; ii++) {
-        queue.set_value(ii, ii);
-    }
-
-    for (int ii = 0; ii < 9; ii++) {
-        int key, value;
-        auto has_result = queue.pop_min(key, value);
-        EXPECT_EQ(value, ii);
-        EXPECT_EQ(key, ii);
-        EXPECT_TRUE(has_result);
-        EXPECT_FALSE(queue.empty());
-    }
-
-    int key, value;
-    auto has_result = queue.pop_min(key, value);
-    EXPECT_EQ(key, 9);
-    EXPECT_EQ(value, 9);
-    EXPECT_TRUE(has_result);
-    EXPECT_TRUE(queue.empty());
-
-    has_result = queue.pop_min(key, value);
-    EXPECT_FALSE(has_result);
-    EXPECT_TRUE(queue.empty());
-}
-
-// Construct an empty queue
-TEST(pairing_queue_fast_reset, construction) {
-    pairing_queue::pairing_queue_fast_reset<int> queue(10);
-
-    int key, value;
-
-    auto has_result = queue.pop_min(key, value);
-    EXPECT_FALSE(has_result);
-    EXPECT_TRUE(queue.empty());
-}
-
-// Construct an empty queue
-TEST(pairing_queue_fast_reset, construction_reset) {
-    pairing_queue::pairing_queue_fast_reset<int> queue(10);
-    queue.reset();
-
-    int key, value;
-
-    auto has_result = queue.pop_min(key, value);
-    EXPECT_FALSE(has_result);
-    EXPECT_TRUE(queue.empty());
-}
-
-// Construct an empty queue and reset it to a given value
-TEST(pairing_queue_fast_reset, insert_single) {
-    pairing_queue::pairing_queue_fast_reset<int> queue(10);
-    queue.reset();
-
-    queue.set_value(5, 0);
-
-    int key, value;
-    auto has_result = queue.pop_min(key, value);
-    EXPECT_EQ(value, 0);
-    EXPECT_EQ(key, 5);
-    EXPECT_TRUE(has_result);
-    EXPECT_TRUE(queue.empty());
-}
-
-TEST(pairing_queue_fast_reset, insert_two) {
-    pairing_queue::pairing_queue_fast_reset<int> queue(10);
-    queue.reset();
-
-    queue.set_value(5, 10);
-    queue.set_value(8, 6);
-
-    int key, value;
-    auto has_result = queue.pop_min(key, value);
-    ASSERT_TRUE(has_result);
-    EXPECT_EQ(value, 6);
-    EXPECT_EQ(key, 8);
-    ASSERT_FALSE(queue.empty());
-
-    has_result = queue.pop_min(key, value);
-    ASSERT_TRUE(has_result);
-    EXPECT_EQ(value, 10);
-    EXPECT_EQ(key, 5);
-    ASSERT_TRUE(queue.empty());
-}
-
-// Construct an empty queue and reset it to a given value
-TEST(pairing_queue_fast_reset, insert_reverse) {
-    pairing_queue::pairing_queue_fast_reset<int> queue(10);
-    queue.reset();
-
-    for (int ii = 0; ii < 10; ii++) {
-        queue.set_value(ii, 10 - ii);
-    }
-
-    for (int ii = 0; ii < 9; ii++) {
-        int key, value;
-        auto has_result = queue.pop_min(key, value);
-        EXPECT_EQ(value, ii + 1);
-        EXPECT_EQ(key, 9 - ii);
-        EXPECT_TRUE(has_result);
-        EXPECT_FALSE(queue.empty());
-    }
-
-    int key, value;
-    auto has_result = queue.pop_min(key, value);
-    EXPECT_EQ(key, 0);
-    EXPECT_EQ(value, 10);
-    EXPECT_TRUE(has_result);
-    EXPECT_TRUE(queue.empty());
-
-    has_result = queue.pop_min(key, value);
-    EXPECT_FALSE(has_result);
-    EXPECT_TRUE(queue.empty());
-}
-
-// Construct an empty queue and reset it to a given value
-TEST(pairing_queue_fast_reset, insert_forward) {
-    pairing_queue::pairing_queue_fast_reset<int> queue(10);
-    queue.reset();
-
-    for (int ii = 0; ii < 10; ii++) {
-        queue.set_value(ii, ii);
+        queue.check_insert(ii, ii);
     }
 
     for (int ii = 0; ii < 9; ii++) {
@@ -253,33 +137,10 @@ class ZeroRNG {
     uint64_t operator()() { return 0ULL; }
 };
 
-// Construct an empty queue
-TEST(pairing_queue_fast_reset_rtb, construction) {
-    pairing_queue::pairing_queue_fast_reset_rtb<int> queue(10);
-
-    int key, value;
-
-    auto has_result = queue.pop_min(key, value);
-    EXPECT_FALSE(has_result);
-    EXPECT_TRUE(queue.empty());
-}
-
-// Construct an empty queue
-TEST(pairing_queue_fast_reset_rtb, construction_reset) {
-    pairing_queue::pairing_queue_fast_reset_rtb<int> queue(10);
-    queue.reset();
-
-    int key, value;
-
-    auto has_result = queue.pop_min(key, value);
-    EXPECT_FALSE(has_result);
-    EXPECT_TRUE(queue.empty());
-}
-
-// Construct an empty queue
-TEST(pairing_queue_fast_reset_rtb, construction_zrng_reset) {
+// Construct an empty queue with an RNG
+TEST(pairing_queue, construction_zrng_reset) {
     ZeroRNG zrng;
-    pairing_queue::pairing_queue_fast_reset_rtb<int> queue(10, zrng);
+    pairing_queue::pairing_queue<int> queue(10, zrng);
 
     int key, value;
 
@@ -288,65 +149,53 @@ TEST(pairing_queue_fast_reset_rtb, construction_zrng_reset) {
     EXPECT_TRUE(queue.empty());
 }
 
-// Construct an empty queue and reset it to a given value
-TEST(pairing_queue_fast_reset_rtb, insert_single) {
-    pairing_queue::pairing_queue_fast_reset_rtb<int> queue(10);
-    queue.reset();
-
-    queue.set_value(5, 0);
-
-    int key, value;
-    auto has_result = queue.pop_min(key, value);
-    EXPECT_EQ(value, 0);
-    EXPECT_EQ(key, 5);
-    EXPECT_TRUE(has_result);
-    EXPECT_TRUE(queue.empty());
-}
-
-// Construct an empty queue and reset it to a given value
-TEST(pairing_queue_fast_reset_rtb, insert_single_rng) {
+// Construct an empty queue, add two tied elements and check that they come out in the proper order
+TEST(pairing_queue, insert_tiebreak) {
     IncreasingRNG irng;
-    pairing_queue::pairing_queue_fast_reset_rtb<int> queue(10, irng);
+    ZeroRNG zrng;
+    pairing_queue::pairing_queue<int> queue(10, irng);
     queue.reset();
 
-    queue.set_value(5, 0);
+    queue.check_insert(5, 0);
+    queue.check_insert(6, 0);
 
     int key, value;
     auto has_result = queue.pop_min(key, value);
     EXPECT_EQ(value, 0);
+    EXPECT_EQ(key, 6);
+    EXPECT_TRUE(has_result);
+    has_result = queue.pop_min(key, value);
+    EXPECT_EQ(value, 0);
     EXPECT_EQ(key, 5);
     EXPECT_TRUE(has_result);
     EXPECT_TRUE(queue.empty());
-}
 
-TEST(pairing_queue_fast_reset_rtb, insert_two) {
-    pairing_queue::pairing_queue_fast_reset_rtb<int> queue(10);
+    queue.reorder(zrng);
+
     queue.reset();
 
-    queue.set_value(5, 10);
-    queue.set_value(8, 6);
-
-    int key, value;
-    auto has_result = queue.pop_min(key, value);
-    ASSERT_TRUE(has_result);
-    EXPECT_EQ(value, 6);
-    EXPECT_EQ(key, 8);
-    ASSERT_FALSE(queue.empty());
+    queue.check_insert(5, 0);
+    queue.check_insert(6, 0);
 
     has_result = queue.pop_min(key, value);
-    ASSERT_TRUE(has_result);
-    EXPECT_EQ(value, 10);
+    EXPECT_EQ(value, 0);
     EXPECT_EQ(key, 5);
-    ASSERT_TRUE(queue.empty());
+    EXPECT_TRUE(has_result);
+    has_result = queue.pop_min(key, value);
+    EXPECT_EQ(value, 0);
+    EXPECT_EQ(key, 6);
+    EXPECT_TRUE(has_result);
+    EXPECT_TRUE(queue.empty());
 }
 
-// Fill a queue with priorities reversed to their keys, and flush it
-TEST(pairing_queue_fast_reset_rtb, insert_reverse) {
-    pairing_queue::pairing_queue_fast_reset_rtb<int> queue(10);
+// Fill a queue with priorities reversed to their keys, and flush it (with an order-preserving tiebreaker)
+TEST(pairing_queue, insert_reverse_zrng) {
+    ZeroRNG zrng;
+    pairing_queue::pairing_queue<int> queue(10, zrng);
     queue.reset();
 
     for (int ii = 0; ii < 10; ii++) {
-        queue.set_value(ii, 10 - ii);
+        queue.check_insert(ii, 10 - ii);
     }
 
     for (int ii = 0; ii < 9; ii++) {
@@ -371,44 +220,13 @@ TEST(pairing_queue_fast_reset_rtb, insert_reverse) {
 }
 
 // Fill a queue with priorities reversed to their keys, and flush it (with an order-preserving tiebreaker)
-TEST(pairing_queue_fast_reset_rtb, insert_reverse_zrng) {
-    ZeroRNG zrng;
-    pairing_queue::pairing_queue_fast_reset_rtb<int> queue(10, zrng);
-    queue.reset();
-
-    for (int ii = 0; ii < 10; ii++) {
-        queue.set_value(ii, 10 - ii);
-    }
-
-    for (int ii = 0; ii < 9; ii++) {
-        int key, value;
-        auto has_result = queue.pop_min(key, value);
-        EXPECT_EQ(value, ii + 1);
-        EXPECT_EQ(key, 9 - ii);
-        EXPECT_TRUE(has_result);
-        EXPECT_FALSE(queue.empty());
-    }
-
-    int key, value;
-    auto has_result = queue.pop_min(key, value);
-    EXPECT_EQ(key, 0);
-    EXPECT_EQ(value, 10);
-    EXPECT_TRUE(has_result);
-    EXPECT_TRUE(queue.empty());
-
-    has_result = queue.pop_min(key, value);
-    EXPECT_FALSE(has_result);
-    EXPECT_TRUE(queue.empty());
-}
-
-// Fill a queue with priorities reversed to their keys, and flush it (with a order-reversing tiebreaker)
-TEST(pairing_queue_fast_reset_rtb, insert_reverse_drng) {
+TEST(pairing_queue, insert_reverse_drng) {
     IncreasingRNG irng;
-    pairing_queue::pairing_queue_fast_reset_rtb<int> queue(10, irng);
+    pairing_queue::pairing_queue<int> queue(10, irng);
     queue.reset();
 
     for (int ii = 0; ii < 10; ii++) {
-        queue.set_value(ii, 10 - ii);
+        queue.check_insert(ii, 10 - ii);
     }
 
     for (int ii = 0; ii < 9; ii++) {
@@ -434,17 +252,17 @@ TEST(pairing_queue_fast_reset_rtb, insert_reverse_drng) {
 
 // Fill a queue with priorities equal to keys, and flush it -- testing resets by different RNGs (shouldn't impact
 // anything)
-TEST(pairing_queue_fast_reset_rtb, insert_forward_reorder_notb) {
+TEST(pairing_queue, insert_forward_reorder_notb) {
     ZeroRNG zrng;
     IncreasingRNG irng;
-    pairing_queue::pairing_queue_fast_reset_rtb<int> queue(10);
+    pairing_queue::pairing_queue<int> queue(10);
     queue.reset();
     queue.reorder(zrng);
     int key, value;
     bool has_result;
 
     for (int ii = 0; ii < 10; ii++) {
-        queue.set_value(ii, ii);
+        queue.check_insert(ii, ii);
     }
 
     for (int ii = 0; ii < 9; ii++) {
@@ -469,7 +287,7 @@ TEST(pairing_queue_fast_reset_rtb, insert_forward_reorder_notb) {
     queue.reorder(irng);
 
     for (int ii = 0; ii < 10; ii++) {
-        queue.set_value(ii, ii);
+        queue.check_insert(ii, ii);
     }
 
     for (int ii = 0; ii < 9; ii++) {
@@ -493,10 +311,10 @@ TEST(pairing_queue_fast_reset_rtb, insert_forward_reorder_notb) {
 
 // Fill a queue with all priorities zero, and flush it -- first with an order-preserving tiebreaker and then
 // order-reversing (should reverse order)
-TEST(pairing_queue_fast_reset_rtb, insert_forward_reorder_tb) {
+TEST(pairing_queue, insert_forward_reorder_tb) {
     ZeroRNG zrng;
     IncreasingRNG irng;
-    pairing_queue::pairing_queue_fast_reset_rtb<int> queue(10);
+    pairing_queue::pairing_queue<int> queue(10);
     queue.reset();
     queue.reorder(zrng);
 
@@ -504,7 +322,7 @@ TEST(pairing_queue_fast_reset_rtb, insert_forward_reorder_tb) {
     bool has_result;
 
     for (int ii = 0; ii < 10; ii++) {
-        queue.set_value(ii, 0);
+        queue.check_insert(ii, 0);
     }
 
     for (int ii = 0; ii < 9; ii++) {
@@ -529,7 +347,7 @@ TEST(pairing_queue_fast_reset_rtb, insert_forward_reorder_tb) {
     queue.reorder(irng);
 
     for (int ii = 0; ii < 10; ii++) {
-        queue.set_value(ii, 0);
+        queue.check_insert(ii, 0);
     }
 
     for (int ii = 0; ii < 9; ii++) {
@@ -548,5 +366,305 @@ TEST(pairing_queue_fast_reset_rtb, insert_forward_reorder_tb) {
 
     has_result = queue.pop_min(key, value);
     EXPECT_FALSE(has_result);
+    EXPECT_TRUE(queue.empty());
+}
+
+// Construct an empty queue
+TEST(decrease_queue, construction) {
+    pairing_queue::decrease_queue<int> queue(10);
+
+    int key, value;
+
+    auto has_result = queue.pop_min(key, value);
+    EXPECT_FALSE(has_result);
+    EXPECT_TRUE(queue.empty());
+}
+
+// Construct an empty queue
+TEST(decrease_queue, construction_reset) {
+    pairing_queue::decrease_queue<int> queue(10);
+    queue.reset();
+
+    int key, value;
+
+    auto has_result = queue.pop_min(key, value);
+    EXPECT_FALSE(has_result);
+    EXPECT_TRUE(queue.empty());
+}
+
+// Construct an empty queue and reset it to a given value
+TEST(decrease_queue, insert_single) {
+    pairing_queue::decrease_queue<int> queue(10);
+    queue.reset();
+
+    queue.check_insert(5, 0);
+
+    int key, value;
+    auto has_result = queue.pop_min(key, value);
+    EXPECT_EQ(value, 0);
+    EXPECT_EQ(key, 5);
+    EXPECT_TRUE(has_result);
+    EXPECT_TRUE(queue.empty());
+}
+
+TEST(decrease_queue, insert_two) {
+    pairing_queue::decrease_queue<int> queue(10);
+    queue.reset();
+
+    queue.check_insert(5, 10);
+    queue.check_insert(8, 6);
+
+    int key, value;
+    auto has_result = queue.pop_min(key, value);
+    ASSERT_TRUE(has_result);
+    EXPECT_EQ(value, 6);
+    EXPECT_EQ(key, 8);
+    ASSERT_FALSE(queue.empty());
+
+    has_result = queue.pop_min(key, value);
+    ASSERT_TRUE(has_result);
+    EXPECT_EQ(value, 10);
+    EXPECT_EQ(key, 5);
+    ASSERT_TRUE(queue.empty());
+}
+
+// Fill a queue with random values, ensure sortedness.
+TEST(pairing_queue, checkinsert_vs_sort) {
+    std::random_device rng;
+    vector<unsigned int> values(10);
+    pairing_queue::pairing_queue<unsigned int> queue(10);
+    queue.reset();
+
+    for (int i = 0; i < 500; i++) {
+        unsigned int v = rng();
+        int k = i % 10;
+        if (queue.check_insert(k, v)) values[k] = v;
+    }
+
+    vector<int> keys;
+    unsigned int last_v;
+    for (int i = 0; i < 10; i++) {
+        int k = queue.min_key();
+        unsigned int v = queue.min_value();
+        queue.delete_min();
+        keys.push_back(k);
+        EXPECT_EQ(v, values[k]);
+        if (i) EXPECT_LE(last_v, v);
+        last_v = v;
+    }
+    EXPECT_TRUE(queue.empty());
+}
+
+// Construct an empty queue and reset it to a given value
+TEST(decrease_queue, insert_reverse) {
+    pairing_queue::decrease_queue<int> queue(10);
+    queue.reset();
+
+    for (int ii = 0; ii < 10; ii++) {
+        queue.check_insert(ii, 10 - ii);
+    }
+
+    for (int ii = 0; ii < 9; ii++) {
+        int key, value;
+        auto has_result = queue.pop_min(key, value);
+        EXPECT_EQ(value, ii + 1);
+        EXPECT_EQ(key, 9 - ii);
+        EXPECT_TRUE(has_result);
+        EXPECT_FALSE(queue.empty());
+    }
+
+    int key, value;
+    auto has_result = queue.pop_min(key, value);
+    EXPECT_EQ(key, 0);
+    EXPECT_EQ(value, 10);
+    EXPECT_TRUE(has_result);
+    EXPECT_TRUE(queue.empty());
+
+    has_result = queue.pop_min(key, value);
+    EXPECT_FALSE(has_result);
+    EXPECT_TRUE(queue.empty());
+}
+
+// Construct an empty queue and reset it to a given value
+TEST(decrease_queue, insert_forward) {
+    pairing_queue::decrease_queue<int> queue(10);
+    queue.reset();
+
+    for (int ii = 0; ii < 10; ii++) {
+        queue.check_insert(ii, ii);
+    }
+
+    for (int ii = 0; ii < 9; ii++) {
+        int key, value;
+        auto has_result = queue.pop_min(key, value);
+        EXPECT_EQ(value, ii);
+        EXPECT_EQ(key, ii);
+        EXPECT_TRUE(has_result);
+        EXPECT_FALSE(queue.empty());
+    }
+
+    int key, value;
+    auto has_result = queue.pop_min(key, value);
+    EXPECT_EQ(key, 9);
+    EXPECT_EQ(value, 9);
+    EXPECT_TRUE(has_result);
+    EXPECT_TRUE(queue.empty());
+
+    has_result = queue.pop_min(key, value);
+    EXPECT_FALSE(has_result);
+    EXPECT_TRUE(queue.empty());
+}
+
+// Fill a queue, decrease all of its values
+TEST(decrease_queue, check_decrease) {
+    pairing_queue::decrease_queue<int> queue(10);
+    queue.reset();
+
+    for (int ii = 0; ii < 10; ii++) {
+        queue.check_insert(ii, ii);
+    }
+    for (int ii = 0; ii < 10; ii++) {
+        queue.check_decrease_value(ii, ii / 2);
+    }
+
+    for (int ii = 0; ii < 9; ii++) {
+        int key, value;
+        auto has_result = queue.pop_min(key, value);
+        EXPECT_EQ(key, ii);
+        EXPECT_EQ(value, ii / 2);
+        EXPECT_TRUE(has_result);
+        EXPECT_FALSE(queue.empty());
+    }
+
+    int key, value;
+    auto has_result = queue.pop_min(key, value);
+    EXPECT_EQ(key, 9);
+    EXPECT_EQ(value, 9 / 2);
+    EXPECT_TRUE(has_result);
+    EXPECT_TRUE(queue.empty());
+
+    has_result = queue.pop_min(key, value);
+    EXPECT_FALSE(has_result);
+    EXPECT_TRUE(queue.empty());
+}
+
+// Fill a queue, and fail to decrease any of its values
+TEST(decrease_queue, check_decrease2) {
+    pairing_queue::decrease_queue<int> queue(10);
+    queue.reset();
+
+    for (int ii = 0; ii < 10; ii++) {
+        queue.check_insert(ii, ii);
+    }
+    for (int ii = 0; ii < 10; ii++) {
+        queue.check_decrease_value(ii, 2 * ii);
+    }
+
+    for (int ii = 0; ii < 9; ii++) {
+        int key, value;
+        auto has_result = queue.pop_min(key, value);
+        EXPECT_EQ(value, ii);
+        EXPECT_EQ(key, ii);
+        EXPECT_TRUE(has_result);
+        EXPECT_FALSE(queue.empty());
+    }
+
+    int key, value;
+    auto has_result = queue.pop_min(key, value);
+    EXPECT_EQ(key, 9);
+    EXPECT_EQ(value, 9);
+    EXPECT_TRUE(has_result);
+    EXPECT_TRUE(queue.empty());
+
+    has_result = queue.pop_min(key, value);
+    EXPECT_FALSE(has_result);
+    EXPECT_TRUE(queue.empty());
+}
+
+// Fill a queue, and increase all of its values
+TEST(decrease_queue, increase) {
+    pairing_queue::decrease_queue<int> queue(10);
+    queue.reset();
+
+    for (int ii = 0; ii < 10; ii++) {
+        queue.check_insert(ii, ii);
+    }
+    for (int ii = 0; ii < 10; ii++) {
+        queue.set_value(ii, 2 * ii);
+    }
+
+    for (int ii = 0; ii < 9; ii++) {
+        int key, value;
+        auto has_result = queue.pop_min(key, value);
+        EXPECT_EQ(key, ii);
+        EXPECT_EQ(value, 2 * ii);
+        EXPECT_TRUE(has_result);
+        EXPECT_FALSE(queue.empty());
+    }
+
+    int key, value;
+    auto has_result = queue.pop_min(key, value);
+    EXPECT_EQ(key, 9);
+    EXPECT_EQ(value, 18);
+    EXPECT_TRUE(has_result);
+    EXPECT_TRUE(queue.empty());
+
+    has_result = queue.pop_min(key, value);
+    EXPECT_FALSE(has_result);
+    EXPECT_TRUE(queue.empty());
+}
+
+// Fill a queue with random values, ensure sortedness.
+TEST(decrease_queue, setvalue_vs_sort) {
+    std::random_device rng;
+    vector<unsigned int> values(10);
+    pairing_queue::decrease_queue<unsigned int> queue(10);
+    queue.reset();
+
+    for (int i = 0; i < 500; i++) {
+        unsigned int v = rng();
+        int k = i % 10;
+        queue.set_value(k, v);
+        values[k] = v;
+    }
+
+    vector<int> keys;
+    unsigned int last_v;
+    for (int i = 0; i < 10; i++) {
+        int k = queue.min_key();
+        unsigned int v = queue.min_value();
+        queue.delete_min();
+        keys.push_back(k);
+        EXPECT_EQ(v, values[k]);
+        if (i) EXPECT_LE(last_v, v);
+        last_v = v;
+    }
+    EXPECT_TRUE(queue.empty());
+}
+
+// Fill a queue with random values, ensure sortedness.
+TEST(decrease_queue, checkdecrease_vs_sort) {
+    std::random_device rng;
+    vector<unsigned int> values(10);
+    pairing_queue::decrease_queue<unsigned int> queue(10);
+    queue.reset();
+
+    for (int i = 0; i < 500; i++) {
+        unsigned int v = rng();
+        int k = i % 10;
+        if (queue.check_decrease_value(k, v)) values[k] = v;
+    }
+
+    vector<int> keys;
+    unsigned int last_v;
+    for (int i = 0; i < 10; i++) {
+        int k = queue.min_key();
+        unsigned int v = queue.min_value();
+        queue.delete_min();
+        keys.push_back(k);
+        EXPECT_EQ(v, values[k]);
+        if (i) EXPECT_LE(last_v, v);
+        last_v = v;
+    }
     EXPECT_TRUE(queue.empty());
 }


### PR DESCRIPTION
This update results from an observation that in node-weighted Dijkstra, the first time a node is discovered, it's always a shortest path.  This update is fairly complex, because we no longer require a decrease-key operation -- the principal data structure, a pairing heap, can be simplified to a 2-pointer structure (instead of the 3 required for a fast decrease-key).  We take the opportunity to improve unit testing, and add randomized tests.  This update is impactful because these queue operations represent about half of the runtime.

