### PR TITLE
Examples of suspend_chains

### DIFF
--- a/examples/suspend_chains.py
+++ b/examples/suspend_chains.py
@@ -25,7 +25,4 @@ blob_C0 = [6,7,14,15]
 suspend_chains = {'A': [blob_A0, blob_A1],'C':[blob_C0]}
 embedding = minorminer.find_embedding(K3, C, suspend_chains=suspend_chains)
 plt.subplot(2,2,4)
-# ISSUE: show labels in networkx iterates through labels and uses key in
-# pos. If label is given but not pos, there's an error.
-# This line fails.
 dnx.draw_chimera_embedding(C, embedding, show_labels=True)

--- a/examples/suspend_chains.py
+++ b/examples/suspend_chains.py
@@ -1,0 +1,31 @@
+import minorminer
+import networkx as nx
+import dwave_networkx as dnx
+import matplotlib.pyplot as plt
+
+K3 = nx.Graph([('A','B'), ('B','C'), ('C','A')])
+plt.subplot(2,2,1)
+nx.draw(K3, with_labels=True)
+C = dnx.chimera_graph(1, 2, coordinates=False)
+plt.subplot(2,2,2)
+dnx.draw_chimera(C, with_labels=True)
+
+# Example with one blob for one node. Source node will use at least one.
+blob = [4,5,12,13]
+suspend_chains = {'A': [blob]}
+embedding = minorminer.find_embedding(K3, C, suspend_chains=suspend_chains)
+plt.subplot(2,2,3)
+dnx.draw_chimera_embedding(C, embedding, with_labels=True)
+
+# Example with one blob for one node, and two blobs for another.
+# Second source node is forced to use at least one in each blob.
+blob_A0 = [4,5]
+blob_A1 = [12,13]
+blob_C0 = [6,7,14,15]
+suspend_chains = {'A': [blob_A0, blob_A1],'C':[blob_C0]}
+embedding = minorminer.find_embedding(K3, C, suspend_chains=suspend_chains)
+plt.subplot(2,2,4)
+# ISSUE: show labels in networkx iterates through labels and uses key in
+# pos. If label is given but not pos, there's an error.
+# This line fails.
+dnx.draw_chimera_embedding(C, embedding, show_labels=True)

--- a/examples/suspend_chains.py
+++ b/examples/suspend_chains.py
@@ -3,29 +3,26 @@ import networkx as nx
 import dwave_networkx as dnx
 import matplotlib.pyplot as plt
 
-K3 = nx.Graph([('A','B'), ('B','C'), ('C','A')])
-plt.subplot(2,2,1)
+K3 = nx.Graph([('A', 'B'), ('B', 'C'), ('C', 'A')])
+plt.subplot(2, 2, 1)
 nx.draw(K3, with_labels=True)
 C = dnx.chimera_graph(1, 2, coordinates=False)
-plt.subplot(2,2,2)
+plt.subplot(2, 2, 2)
 dnx.draw_chimera(C, with_labels=True)
 
 # Example with one blob for one node. Source node will use at least one.
-blob = [4,5,12,13]
+blob = [4, 5, 12, 13]
 suspend_chains = {'A': [blob]}
 embedding = minorminer.find_embedding(K3, C, suspend_chains=suspend_chains)
-plt.subplot(2,2,3)
+plt.subplot(2, 2, 3)
 dnx.draw_chimera_embedding(C, embedding, with_labels=True)
 
 # Example with one blob for one node, and two blobs for another.
 # Second source node is forced to use at least one in each blob.
-blob_A0 = [4,5]
-blob_A1 = [12,13]
-blob_C0 = [6,7,14,15]
-suspend_chains = {'A': [blob_A0, blob_A1],'C':[blob_C0]}
+blob_A0 = [4, 5]
+blob_A1 = [12, 13]
+blob_C0 = [6, 7, 14, 15]
+suspend_chains = {'A': [blob_A0, blob_A1], 'C': [blob_C0]}
 embedding = minorminer.find_embedding(K3, C, suspend_chains=suspend_chains)
-plt.subplot(2,2,4)
-# ISSUE: show labels in networkx iterates through labels and uses key in
-# pos. If label is given but not pos, there's an error.
-# This line fails.
+plt.subplot(2, 2, 4)
 dnx.draw_chimera_embedding(C, embedding, show_labels=True)


### PR DESCRIPTION
Just thought it would be useful to have.
But also, wanted to point out that, since the internal pins are also returned in the embedding, a naive use of the embedding with the drawing capabilities, will cause an error if show_labels=True is used.

Maybe there's nothing to do here but the user should be aware of this. Or maybe the drawing package should handle it... or... networkx shouldn't use label keys to address the pos dictionary, which is what causes the error.