### PR TITLE
Visible parameters of the embedding method

### DIFF
--- a/python/minorminer.pyx
+++ b/python/minorminer.pyx
@@ -42,6 +42,11 @@ This implementation adds several useful features:
 include "minorminer.pxi"
 import os
 
+parameters = {"max_no_improvement", "random_seed", "timeout", "tries", "verbose",
+         "fixed_chains", "initial_chains", "max_fill", "chainlength_patience",
+         "return_overlap", "skip_initialization", "inner_rounds", "threads",
+         "restrict_chains", "suspend_chains", "max_beta"}
+
 def find_embedding(S, T, **params):
     """
     find_embedding(S, T, **params)
@@ -588,4 +593,4 @@ cdef _read_graph(input_graph &g, E):
         g.push_back(L[a],L[b])
     return L
 
-__all__ = ["find_embedding", "VARORDER", "miner"]
+__all__ = ["find_embedding", "VARORDER", "miner", "parameters"]

--- a/python/minorminer.pyx
+++ b/python/minorminer.pyx
@@ -232,13 +232,8 @@ cdef class _input_parser:
 
         self.opts.localInteractionPtr.reset(new LocalInteractionPython())
 
-        names = {"max_no_improvement", "random_seed", "timeout", "tries", "verbose",
-                 "fixed_chains", "initial_chains", "max_fill", "chainlength_patience",
-                 "return_overlap", "skip_initialization", "inner_rounds", "threads",
-                 "restrict_chains", "suspend_chains", "max_beta"}
-
         for name in params:
-            if name not in names:
+            if name not in parameters:
                 raise ValueError("%s is not a valid parameter for find_embedding"%name)
 
         try: self.opts.max_no_improvement = int( params["max_no_improvement"] )


### PR DESCRIPTION
Is this something that could be considered?
Looking ahead into having other embedding methods, or more "sophisticated" `Composites `that can make use of the flexibility of `minorminer`, it would be very useful to be able to read out the parameters and eventually add them to the sampler parameters. e.g:
```
class ???EmbeddingComposite(...
...
param = self.child.parameters.copy()
param['embedding_parameters'] = self._embedding_method.parameters.copy()
...
```

```
# Example usage
import minorminer

print(minorminer.parameters)
>>> {'chainlength_patience',
 'fixed_chains',
 'initial_chains',
 'inner_rounds',
 'max_beta',
 'max_fill',
 'max_no_improvement',
 'random_seed',
 'restrict_chains',
 'return_overlap',
 'skip_initialization',
 'suspend_chains',
 'threads',
 'timeout',
 'tries',
 'verbose'}

```
