### PR TITLE
Build python interface in RTD

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 breathe<4.13.0
 sphinx-rtd-theme==0.*
 sphinx==1.*
-minorminer
+cython==0.27


### PR DESCRIPTION
@boothby, this is to close #75. It seems to work for my fork: https://minorminer-docs.readthedocs.io/en/latest/reference/pythondocs.html

Before running it we need to update the Advanced Settings in RTD to the following:
* Requirements file: docs/requirements.txt
* Install Project: True
I can do this if you like.

@davage, this will hopefully add the Python interface.  