### PR TITLE
Stop printing errors to stderr

### DIFF
--- a/include/pathfinder.hpp
+++ b/include/pathfinder.hpp
@@ -569,16 +569,18 @@ class pathfinder_base : public pathfinder_public_interface {
             if (initEmbedding.linked()) {
                 currEmbedding = initEmbedding;
             } else {
-                ep.error(
-                        "cannot bootstrap from initial embedding.  stopping.  disable skip_initialization or throw "
-                        "this embedding away\n");
-                return 0;
+                throw BadInitializationException(
+                        "cannot bootstrap from initial embedding.  "
+                        "disable skip_initialization or throw this embedding away");
             }
         } else {
             currEmbedding = initEmbedding;
             if (initialization_pass(currEmbedding) <= 0) {
-                ep.error("failed during initialization. embeddings may be invalid.\n");
-                return 0;
+                throw BadInitializationException(
+                        "Failed during initialization.  This typically "
+                        "occurs when the source graph is unreasonably large or when the embedding "
+                        "problem is over-constrained (via max_fill, initial_chains, fixed_chains, "
+                        "and/or restrict_chains).");
             }
         }
         ep.major_info("initialized\n");

--- a/minorminer/_minorminer.pyx
+++ b/minorminer/_minorminer.pyx
@@ -168,8 +168,9 @@ def find_embedding(S, T, **params):
 
         fixed_chains: Fixed chains inserted into an embedding before the
             initialization pass. As the algorithm proceeds, these chains are not
-            allowed to change. Missing or empty entries are ignored. A
-            dictionary, where fixed_chains[i] is a list of qubit labels.
+            allowed to change, and the qubits used by these chains are not used by
+            other chains. Missing or empty entries are ignored. A dictionary, where
+            fixed_chains[i] is a list of qubit labels.
 
         restrict_chains: Throughout the algorithm, we maintain the condition
             that chain[i] is a subset of restrict_chains[i] for each i, except


### PR DESCRIPTION
See conversation in issue #28 and #62 -- there's a couple of annoying conditions where errors are printing to stderr rather than raising exceptions.  This should fix that.