### PR TITLE
address multiple compiler warnings

### DIFF
--- a/include/chain.hpp
+++ b/include/chain.hpp
@@ -78,7 +78,7 @@ class chain {
         clear();
         for (auto &q : c) {
             data.emplace(q, pair<int, int>(q, 1));
-            minorminer_assert(0 <= q && q < qubit_weight.size());
+            minorminer_assert(0 <= q && q < static_cast<int>(qubit_weight.size()));
             qubit_weight[q]++;
         }
         DIAGNOSE_CHAIN();
@@ -96,10 +96,10 @@ class chain {
     }
 
     //! number of qubits in chain
-    inline int size() const { return data.size(); }
+    inline size_t size() const { return data.size(); }
 
     //! returns 0 if `q` is not contained in `this`, 1 otherwise
-    inline int count(const int q) const { return data.count(q); }
+    inline size_t count(const int q) const { return data.count(q); }
 
     //! get the qubit, in `this`, which links `this` to the chain of x
     //!(if x==label, interpret the linking qubit as the chain's root)
@@ -229,13 +229,13 @@ class chain {
 
     //! store this chain into a `frozen_chain`, unlink all chains from
     //! this, and clear()
-    inline int freeze(vector<chain> &others, frozen_chain &keep) {
+    inline size_t freeze(vector<chain> &others, frozen_chain &keep) {
         keep.clear();
         for (auto &v_p : links) {
             keep.links.emplace(v_p);
             int v = v_p.first;
             if (v != label) {
-                minorminer_assert(0 <= v && v < others.size());
+                minorminer_assert(0 <= v && v < static_cast<int>(others.size()));
                 int q = others[v].drop_link(label);
                 keep.links.emplace(-v - 1, q);
             }
@@ -260,7 +260,7 @@ class chain {
                 links.emplace(v_p);
             } else {
                 v = -v - 1;
-                minorminer_assert(0 <= v && v < others.size());
+                minorminer_assert(0 <= v && v < static_cast<int>(others.size()));
                 others[v].set_link(label, v_p.second);
             }
         }
@@ -279,7 +279,7 @@ class chain {
         minorminer_assert(q != -1);
         minorminer_assert(p != -1);
 
-        while ((chainsize == 0 || size() < chainsize) && ep.accepts_qubit(label, p)) {
+        while ((chainsize == 0 || static_cast<int>(size()) < chainsize) && ep.accepts_qubit(label, p)) {
             int r = other.trim_leaf(p);
             minorminer_assert(other.size() >= 1);
             if (r == p) break;

--- a/include/embedding.hpp
+++ b/include/embedding.hpp
@@ -80,7 +80,7 @@ class embedding {
             auto &c = var_embedding[v];
             int root = vC.second[0];
             c.set_link(v, root);
-            int hits = 0;
+            size_t hits = 0;
             stack.push_back(root);
             while (stack.size()) {
                 hits++;
@@ -368,7 +368,6 @@ class embedding {
         int err = 0;
         vector<int> tmp_weight(num_qubits + num_reserved, 0);
         int zeros = 0;
-        int bad_parents = false;
         for (int v = 0; v < num_vars + num_fixed; v++) {
             if (!ep.fixed(v)) {
                 for (auto &q : var_embedding.at(v)) {
@@ -417,7 +416,6 @@ class embedding {
             err = 1;
         }
         for (int v = num_vars + num_fixed; v--;) {
-            int n = chainsize(v);
             vector<int> good_links(num_vars + num_fixed, 0);
             if (chainsize(v)) {
                 for (auto &u : ep.var_neighbors(v)) {

--- a/include/embedding_problem.hpp
+++ b/include/embedding_problem.hpp
@@ -242,7 +242,7 @@ class embedding_problem_base {
         if (ultramax_weight < 2) throw MinorMinerException("problem is too large to avoid overflow");
 
         if (ultramax_weight < params.max_fill)
-            weight_bound = std::floor(ultramax_weight);
+            weight_bound = static_cast<int>(std::floor(ultramax_weight));
         else
             weight_bound = params.max_fill;
 
@@ -254,9 +254,9 @@ class embedding_problem_base {
 
   private:
     //! computes an upper bound on the distances computed during tearout & replace
-    unsigned int compute_margin() {
+    size_t compute_margin() {
         if (num_q == 0) return 0;
-        unsigned int max_degree =
+        size_t max_degree =
                 std::max_element(begin(var_nbrs), end(var_nbrs),
                                  [](const vector<int> &a, const vector<int> &b) { return a.size() < b.size(); })
                         ->size();
@@ -275,7 +275,7 @@ class embedding_problem_base {
         double base = min(exp2(log2base), min(max_beta, round_beta));
         double power = 1;
         for (int i = 0; i <= max_weight; i++) {
-            weight_table[i] = power;
+            weight_table[i] = static_cast<distance_t>(power);
             power *= base;
         }
         for (int i = max_weight + 1; i < 64; i++) weight_table[i] = max_distance;
@@ -302,7 +302,7 @@ class embedding_problem_base {
     //! transposition before returning the reference
     const vector<int> &var_neighbors(int u, rndswap_first) {
         if (var_nbrs[u].size() > 2) {
-            int i = randint(0, var_nbrs[u].size() - 2);
+            size_t i = randint(0, var_nbrs[u].size() - 2);
             std::swap(var_nbrs[u][i], var_nbrs[u][i + 1]);
         } else if (var_nbrs[u].size() == 2) {
             if (randint(0, 1)) std::swap(var_nbrs[u][0], var_nbrs[u][1]);
@@ -387,7 +387,7 @@ class embedding_problem_base {
         visited[x] = 1;
         while (front < component.size()) {
             int x = component[front++];
-            unsigned int lastback = component.size();
+            size_t lastback = component.size();
             for (auto &y : neighbors[x]) {
                 if (!visited[y]) {
                     visited[y] = 1;

--- a/include/find_embedding.hpp
+++ b/include/find_embedding.hpp
@@ -84,9 +84,9 @@ class parameter_processor {
     }
 
     vector<int> _inverse_permutation(vector<int> &f) {
-        int n = f.size();
+        size_t n = f.size();
         vector<int> r(n);
-        for (int i = n; i--;) {
+        for (size_t i = n; i--;) {
             r.at(f[i]) = i;
         }
         return r;
@@ -222,7 +222,7 @@ int findEmbedding(graph::input_graph &var_g, graph::input_graph &qubit_g, option
 
     if (params.return_overlap || success) {
         chains.resize(var_g.num_nodes());
-        for (int u = 0; u < var_g.num_nodes(); u++) {
+        for (size_t u = 0; u < var_g.num_nodes(); u++) {
             pf.get_chain(u, chains[u]);
         }
     } else {

--- a/include/graph.hpp
+++ b/include/graph.hpp
@@ -61,7 +61,7 @@ class input_graph {
     // In
     std::vector<int> edges_aside;
     std::vector<int> edges_bside;
-    int _num_nodes;
+    size_t _num_nodes;
 
     //! this method converts a std::vector of sets into a std::vector of sets, ensuring
     //! that element i is not contained in nbrs[i].  this method is called by
@@ -70,7 +70,7 @@ class input_graph {
     //! in a contiguous memory segment.
     std::vector<std::vector<int>> _to_vectorhoods(std::vector<std::set<int>>& _nbrs) const {
         std::vector<std::vector<int>> nbrs;
-        for (int i = 0; i < _num_nodes; i++) {
+        for (size_t i = 0; i < _num_nodes; i++) {
             std::set<int>& nbrset = _nbrs[i];
             nbrset.erase(i);
             nbrs.emplace_back(std::begin(nbrset), std::end(nbrset));
@@ -104,15 +104,15 @@ class input_graph {
     int b(const int i) const { return edges_bside[i]; }
 
     //! Return the size of the graph in nodes
-    int num_nodes() const { return _num_nodes; }
+    size_t num_nodes() const { return _num_nodes; }
     //! Return the size of the graph in edges
-    int num_edges() const { return edges_aside.size(); }
+    size_t num_edges() const { return edges_aside.size(); }
 
     //! Add an edge to the graph
     void push_back(int ai, int bi) {
         edges_aside.push_back(ai);
         edges_bside.push_back(bi);
-        _num_nodes = std::max(_num_nodes, std::max(ai, bi) + 1);
+        _num_nodes = std::max(_num_nodes, static_cast<size_t>(std::max(ai, bi) + 1));
     }
 
   private:
@@ -124,7 +124,7 @@ class input_graph {
     inline std::vector<std::vector<int>> __get_neighbors(const unaryint<T1>& sources, const unaryint<T2>& sinks,
                                                          const unaryint<T3>& relabel, const unaryint<T4>& mask) const {
         std::vector<std::set<int>> _nbrs(_num_nodes);
-        for (int i = num_edges(); i--;) {
+        for (size_t i = num_edges(); i--;) {
             int ai = a(i), bi = b(i);
             if (mask(ai)) {
                 int rai = relabel(ai), rbi = relabel(bi);
@@ -135,7 +135,7 @@ class input_graph {
         return _to_vectorhoods(_nbrs);
     }
 
-    //! smash the types throgh unaryint
+    //! smash the types through unaryint
     template <typename T1, typename T2, typename T3 = void*, typename T4 = bool>
     inline std::vector<std::vector<int>> _get_neighbors(const T1& sources, const T2& sinks, const T3& relabel = nullptr,
                                                         const T4& mask = true) const {
@@ -197,14 +197,14 @@ class components {
         to store the parent and rank data for union/find operations.
         */
         std::vector<int>& parent = index;
-        for (int x = g.num_nodes(); x--;) {
+        for (size_t x = g.num_nodes(); x--;) {
             parent[x] = x;
         }
-        for (int i = g.num_edges(); i--;) {
+        for (size_t i = g.num_edges(); i--;) {
             __init_union(g.a(i), g.b(i));
         }
 
-        for (int x = g.num_nodes(); x--;) component[__init_find(x)].push_back(x);
+        for (size_t x = g.num_nodes(); x--;) component[__init_find(x)].push_back(x);
 
         sort(std::begin(component), std::end(component),
              [](const std::vector<int>& a, const std::vector<int>& b) { return a.size() > b.size(); });
@@ -217,13 +217,13 @@ class components {
         The labels associated with component[c] are the numbers 0 through
         component[c].size()-1.
         */
-        for (int c = 0; c < g.num_nodes(); c++) {
+        for (size_t c = 0; c < g.num_nodes(); c++) {
             std::vector<int>& comp = component[c];
             auto back = std::end(comp);
             for (auto front = std::begin(comp); front < back; front++)
                 while (front < back && reserve(*front)) iter_swap(front, --back);
             if (comp.size()) {
-                for (int j = comp.size(); j--;) {
+                for (size_t j = comp.size(); j--;) {
                     label[comp[j]] = j;
                     index[comp[j]] = c;
                 }
@@ -234,7 +234,7 @@ class components {
                 break;
             }
         }
-        for (int i = g.num_edges(); i--;) {
+        for (size_t i = g.num_edges(); i--;) {
             int a = g.a(i);
             int b = g.b(i);
             component_g[index[a]].push_back(label[a], label[b]);
@@ -250,20 +250,20 @@ class components {
     const std::vector<int>& nodes(int c) const { return component[c]; }
 
     //! Get the number of connected components in the graph
-    int size() const { return component_g.size(); }
+    size_t size() const { return component_g.size(); }
 
     //! returns the number of reserved nodes in a component
-    int num_reserved(int c) const { return _num_reserved[c]; }
+    size_t num_reserved(int c) const { return _num_reserved[c]; }
 
     //! Get the size (in nodes) of a component
-    int size(int c) const { return component_g[c].num_nodes(); }
+    size_t size(int c) const { return component_g[c].num_nodes(); }
 
     //! Get a const reference to the graph object of a component
     const input_graph& component_graph(int c) const { return component_g[c]; }
 
     //! Construct a neighborhood list for component c, with reserved nodes as sources
     std::vector<std::vector<int>> component_neighbors(int c) const {
-        return component_g[c].get_neighbors_sources(size(c) - num_reserved(c));
+        return component_g[c].get_neighbors_sources(static_cast<int>(size(c)) - static_cast<int>(num_reserved(c)));
     }
 
     //! translate nodes from the input graph, to their labels in component c
@@ -321,4 +321,4 @@ class components {
     std::vector<std::vector<int>> component;
     std::vector<input_graph> component_g;
 };
-}
+}  // namespace graph

--- a/minorminer/src/pyutil.hpp
+++ b/minorminer/src/pyutil.hpp
@@ -13,7 +13,7 @@ class LocalInteractionPython : public find_embedding::LocalInteraction {
     virtual void displayErrorImpl(int, const std::string &msg) const { PySys_WriteStderr("%s", msg.c_str()); }
 
     virtual bool cancelledImpl() const {
-        bool cancelled = PyErr_CheckSignals();
+        bool cancelled = static_cast<bool>(PyErr_CheckSignals());
         if (cancelled) PyErr_Clear();
         return cancelled;
     }
@@ -38,7 +38,7 @@ class LocalInteractionLogger : public find_embedding::LocalInteraction {
     }
 
     virtual bool cancelledImpl() const {
-        bool cancelled = PyErr_CheckSignals();
+        bool cancelled = static_cast<bool>(PyErr_CheckSignals());
         if (cancelled) PyErr_Clear();
         return cancelled;
     }

--- a/tests/test_chain.cpp
+++ b/tests/test_chain.cpp
@@ -14,7 +14,7 @@ struct embedding {
 
 class embedding_problem_t {
   public:
-    inline bool accepts_qubit(int v, int q) { return true; }
+    inline bool accepts_qubit(int /*v*/, int /*q*/) { return true; }
 };
 
 //


### PR DESCRIPTION
Pawing through build logs of our various CI environments, I was a little surprised by the number of warnings that I haven't been seeing in my familiar gcc environment.  This patch should clean things up a fair bit.