### PR TITLE
modernize the C++ by replacing macros with templates

### DIFF
--- a/include/debug.hpp
+++ b/include/debug.hpp
@@ -1,16 +1,15 @@
 #pragma once
+#include "util.hpp"
+namespace find_embedding {
 
-#ifdef CPPDEBUG
-#ifdef NDBUG
-#undef NDBUG
-#endif
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-#include <assert.h>
-#define minorminer_assert(X) assert(X)
-#else
-#ifndef minorminer_assert
-#define minorminer_assert(X)
-#endif
-#endif
+struct disable_asserts {
+    static inline void assertion(bool /*statement*/) {}
+};
+
+struct enable_asserts {
+    static inline void assertion(bool statement) {
+        if (!statement) throw MinorMinerException();
+    }
+};
+
+}  // namespace find_embedding

--- a/include/graph.hpp
+++ b/include/graph.hpp
@@ -4,9 +4,10 @@
 #include <random>
 #include <set>
 #include <vector>
+#include "debug.hpp"
 #include "util.hpp"
 
-namespace graph {
+namespace find_embedding {
 
 template <typename T>
 class unaryint {
@@ -88,7 +89,8 @@ class input_graph {
     //! @param bside List of nodes describing edges.
     input_graph(int n_v, const std::vector<int>& aside, const std::vector<int>& bside)
             : edges_aside(aside), edges_bside(bside), _num_nodes(n_v) {
-        minorminer_assert(aside.size() == bside.size());
+        if (aside.size() != bside.size())
+            throw CorruptParametersException("Graph constructor invalid: aside and bside must have same size");
     }
 
     //! Remove all edges and nodes from a graph.
@@ -289,6 +291,13 @@ class components {
         }
     }
 
+    //! translate nodes from labels in component c, back to their original input labels
+    //! this version is done inplace on the `nodes` vector
+    void from_component(const int c, std::vector<int>& nodes) const {
+        auto& comp = component[c];
+        for (size_t i = 0; i < nodes.size(); i++) nodes[i] = comp[nodes[i]];
+    }
+
   private:
     int __init_find(int x) {
         // NEVER CALL AFTER INITIALIZATION
@@ -321,4 +330,4 @@ class components {
     std::vector<std::vector<int>> component;
     std::vector<input_graph> component_g;
 };
-}  // namespace graph
+}  // namespace find_embedding

--- a/minorminer/_minorminer_h.pxi
+++ b/minorminer/_minorminer_h.pxi
@@ -74,7 +74,7 @@ cdef extern from "src/pyutil.hpp" namespace "":
 
     void handle_exceptions()
 
-cdef extern from "../include/graph.hpp" namespace "graph":
+cdef extern from "../include/graph.hpp" namespace "find_embedding":
     cppclass input_graph:
         input_graph()
         void push_back(int,int)
@@ -113,29 +113,22 @@ cdef extern from "../include/chain.hpp" namespace "find_embedding":
         void quickPass(const vector[int] &, int, int, bool, bool, double) except +handle_exceptions
         void quickPass(VARORDER, int, int, bool, bool, double) except +handle_exceptions
 
-    cppclass chain:
-        chain(vector[int] &w, int l)
-        inline int size() const 
-        inline int count(const int q) const
-        inline int get_link(const int x) const 
-        inline void set_link(const int x, const int q)
-        inline int drop_link(const int x)
-        inline void set_root(const int q)
-        inline void clear()
-        inline void add_leaf(const int q, const int parent)
-        inline int trim_branch(int q)
-        inline int trim_leaf(int q)
-        inline int parent(const int q) const
-        inline int refcount(const int q) const
-        void link_path(chain &other, int q, const vector [int] &parents)
-        inline void diagnostic(char *last_op)
-
-
-cdef class cppembedding:
-    cdef vector[chain] chains
-    cdef vector[int] qubit_weights
-    def __cinit__(self, int num_vars, int num_qubits):
-        pass
+#    cppclass chain[T]:
+#        chain(vector[int] &w, int l)
+#        inline int size() const 
+#        inline int count(const int q) const
+#        inline int get_link(const int x) const 
+#        inline void set_link(const int x, const int q)
+#        inline int drop_link(const int x)
+#        inline void set_root(const int q)
+#        inline void clear()
+#        inline void add_leaf(const int q, const int parent)
+#        inline int trim_branch(int q)
+#        inline int trim_leaf(int q)
+#        inline int parent(const int q) const
+#        inline int refcount(const int q) const
+#        void link_path(chain &other, int q, const vector [int] &parents)
+#        inline void diagnostic(char *last_op)
 
 cdef extern from "../include/find_embedding.hpp" namespace "find_embedding":
     int findEmbedding(input_graph, input_graph, optional_parameters, vector[vector[int]]&) except +handle_exceptions

--- a/minorminer/src/pyutil.hpp
+++ b/minorminer/src/pyutil.hpp
@@ -57,6 +57,8 @@ void handle_exceptions() {
         PyErr_SetString(PyExc_RuntimeError, e.what());
     } catch (const find_embedding::CorruptEmbeddingException &e) {
         PyErr_SetString(PyExc_AssertionError, e.what());
+    } catch (const find_embedding::AssertionException &e) {
+        PyErr_SetString(PyExc_AssertionError, e.what());
     }
 }
 


### PR DESCRIPTION
This is a bit of an experiment.  I'm interested in modernizing the C++, replacing preprocessor directives with templates.  The first commit seems to have a significant impact on performance (a hit of about 15% on a standard benchmark, which is unacceptable).  I'm posting this as a PR mostly to see what explodes on various platforms (I've already found some deficiencies in clang).