### PR TITLE
Layout dnx

### DIFF
--- a/minorminer/layout/__init__.py
+++ b/minorminer/layout/__init__.py
@@ -4,7 +4,7 @@ import networkx as nx
 
 import minorminer as mm
 
-from .layout import Layout, p_norm
+from .layout import Layout, dnx_layout, p_norm
 from .placement import Placement, closest
 
 
@@ -139,7 +139,11 @@ def _parse_layout_parameter(S, T, layout, layout_kwargs):
     if isinstance(t_layout, Layout):
         T_layout = t_layout
     else:
+        # Use the dnx_layout if possible
+        if T.graph.get("family") in ("chimera", "pegasus"):
+            T_layout = Layout(T, layout=dnx_layout, **layout_kwargs)
         # Assumes t_layout a callable or implements a mapping interface
-        T_layout = Layout(T, layout=t_layout, **layout_kwargs)
+        else:
+            T_layout = Layout(T, layout=t_layout, **layout_kwargs)
 
     return S_layout, T_layout

--- a/minorminer/layout/tests/common.py
+++ b/minorminer/layout/tests/common.py
@@ -17,6 +17,7 @@ class TestLayoutPlacement(unittest.TestCase):
         self.G = nx.Graph()
         self.H = nx.complete_graph(1)
         self.C = dnx.chimera_graph(4)
+        self.P = dnx.pegasus_graph(4)
 
         # Compute some layouts
         self.S_layout = mml.Layout(self.S)

--- a/minorminer/layout/tests/test_find_embedding.py
+++ b/minorminer/layout/tests/test_find_embedding.py
@@ -15,7 +15,11 @@ class TestFindEmb(TestLayoutPlacement):
         """
         Minimal find_embedding call
         """
+        # Test a dnx_graph
         mml.find_embedding(self.S, self.C)
+
+        # Test a non-dnx_graph
+        mml.find_embedding(self.S_small, self.S)
 
     def test_timeout(self):
         """

--- a/minorminer/layout/tests/test_layout.py
+++ b/minorminer/layout/tests/test_layout.py
@@ -15,12 +15,12 @@ from .common import TestLayoutPlacement
 class TestLayout(TestLayoutPlacement):
     def test_pnorm(self):
         """
-        Test the p_norm layout strategy.
+        Test the p_norm layout algorithm.
         """
         # Some specs to test with
         low_dim = random.randint(3, 9)
         high_dim = len(self.S_small)
-        center = (1, 1)
+        center = low_dim*(1, )
         scale = random.random()*random.randint(1, 10)
 
         # Default behavior
@@ -48,14 +48,48 @@ class TestLayout(TestLayoutPlacement):
         mml.p_norm(self.S_small, p=3)
         mml.p_norm(self.S_small, p=float("inf"))
 
-        # # Playing with a starting_layout and a dimension
-        # starting_layout = nx.spectral_layout(self.S, dim=dim)
-        # layout_in = mml.Layout(
-        #     self.S, mml.p_norm, starting_layout=starting_layout)
-        # layout_out = mml.Layout(
-        #     self.S, mml.p_norm, starting_layout=nx.spectral_layout, dim=dim)
-        # self.assertLayoutEqual(self.S, layout_in, layout_out)
-        # self.assertIsLayout(self.S, layout_in)
+        # Test through the Layout object
+        layout = mml.Layout(self.S_small, mml.p_norm, dim=low_dim,
+                            center=center, scale=scale)
+        self.assertArrayEqual(layout.center, center)
+        self.assertAlmostEqual(layout.scale, scale)
+
+    def test_dnx(self):
+        """
+        Test the dnx layout.
+        """
+        # Some specs to test with
+        dim = random.randint(3, 9)
+        center = dim*(1, )
+        scale = random.random()*random.randint(1, 10)
+
+        # Default behavior
+        # Chimera
+        mml.dnx_layout(self.C)
+        # Pegasus
+        mml.dnx_layout(self.P)
+
+        # Passing in dim
+        mml.dnx_layout(self.C, dim=dim)
+
+        # Passing in center
+        mml.dnx_layout(self.C, center=center)
+
+        # Passing in scale
+        mml.dnx_layout(self.C, scale=scale)
+
+        # Test through the Layout object
+        layout = mml.Layout(self.C, mml.dnx_layout, dim=dim,
+                            center=center, scale=scale)
+        self.assertArrayEqual(layout.center, center)
+        self.assertAlmostEqual(layout.scale, scale)
+
+        # Test non-dnx_graph
+        self.assertRaises(ValueError, mml.dnx_layout, self.S)
+
+        # Test dim and center mismatch
+        self.assertRaises(ValueError, mml.dnx_layout,
+                          self.C, dim=3, center=(0, 0))
 
     def test_precomputed_layout(self):
         """


### PR DESCRIPTION
The `dnx_layout` is introduced.

- This is essentially the same as calling `dnx.chimera_layout` or `dnx.pegasus_layout` and recentering and scaling so that the layouts are centered at the origin and have scale a function of the number of rows/columns in the dnx_graph.
- `dnx_layout` is called by default from `find_embedding` where possible.

This also updates `p_norm` so that it behaves like a layout should, i.e. it has its own default behavior with regard to dimension, center, and scale.