### PR TITLE
Placement intersection

### DIFF
--- a/minorminer/layout/__init__.py
+++ b/minorminer/layout/__init__.py
@@ -5,7 +5,7 @@ import networkx as nx
 import minorminer as mm
 
 from .layout import Layout, dnx_layout, p_norm
-from .placement import Placement, closest
+from .placement import Placement, closest, intersection
 
 
 def find_embedding(

--- a/minorminer/layout/placement.py
+++ b/minorminer/layout/placement.py
@@ -8,6 +8,155 @@ from scipy import spatial
 from . import layout
 
 
+def intersection(S_layout, T_layout, scale_ratio=None, **kwargs):
+    """
+    Map each vertex of S to its nearest row/column intersection qubit in T (T must be a D-Wave hardware graph).
+
+    Parameters
+    ----------
+    S_layout : layout.Layout
+        A layout for S; i.e. a map from S to R^d.
+    T_layout : layout.Layout
+        A layout for T; i.e. a map from T to R^d.
+    scale_ratio : float (default None)
+        If None, S_layout is not scaled. Otherwise, S_layout is scaled to scale_ratio*T_layout.scale.
+
+    Returns
+    -------
+    placement : dict
+        A mapping from vertices of S (keys) to vertices of T (values).
+    """
+    # Extract the target graph
+    T = T_layout.G
+
+    # Currently only implemented for 2d chimera
+    if T.graph.get("family") != "chimera":
+        raise NotImplementedError(
+            "This strategy is currently only implemented for Chimera.")
+
+    # Bin vertices of S and T into a grid graph G
+    G = _intersection_binning(S_layout, T, scale_ratio)
+
+    placement = {}
+    for _, data in G.nodes(data=True):
+        for v in data["variables"]:
+            placement[v] = data["qubits"]
+
+    return placement
+
+
+def _intersection_binning(S_layout, T, scale_ratio):
+    """
+    Map the vertices of S to the "intersection graph" of T. This modifies the grid graph G by assigning vertices 
+    from S and T to vertices of G.
+
+    Parameters
+    ----------
+    S_layout : layout.Layout
+        A layout for S; i.e. a map from S to R^d.
+    T : networkx.Graph
+        The target graph to embed S in.
+    scale_ratio : float (default None)
+        If None, S_layout is not scaled. Otherwise, S_layout is scaled to scale_ratio*T_layout.scale.
+
+    Returns
+    -------
+    G : networkx.Graph
+        A grid graph. Each vertex of G contains data attributes "variables" and "qubits", that is, respectively 
+        vertices of S and T assigned to that vertex.  
+    """
+    # Scale the layout so that for each unit-cell edge, we have an integer point.
+    m, n, t = T.graph["rows"], T.graph["columns"], T.graph["tile"]
+
+    # --- Make the "intersection graph" of the dnx_graph
+    # Grid points correspond to intersection rows and columns of the dnx_graph
+    G = nx.grid_2d_graph(t*n, t*m)
+
+    # Determine the scale for putting things in the positive quadrant
+    scale = (t*min(n, m)-1)/2
+
+    # Get the row, column mappings for the dnx graph
+    lattice_mapping = _lookup_intersection_coordinates(T)
+
+    # Less efficient, but more readable to initialize all at once
+    for v in G:
+        G.nodes[v]["qubits"] = set()
+        G.nodes[v]["variables"] = set()
+
+    # Add qubits (vertices of T) to grid points
+    for int_point, Q in lattice_mapping.items():
+        G.nodes[int_point]["qubits"] |= Q
+
+    # --- Map the S_layout to the grid
+    # "Zoom in" on layout_S so that the integer points are better represented
+    if scale_ratio:
+        S_layout.scale = scale_ratio*scale
+    else:
+        S_layout.scale *= t
+
+    # Center to the positive orthant
+    S_layout.center = 2*(scale, )
+
+    # Add "variables" (vertices from S) to grid points too
+    for v, pos in S_layout.items():
+        grid_point = tuple(int(x) for x in np.round(pos))
+        G.nodes[grid_point]["variables"].add(v)
+
+    return G
+
+
+def _lookup_intersection_coordinates(G):
+    """
+    For a dwave_networkx graph G, this returns a dictionary mapping the lattice points to sets of vertices of G. 
+    - Chimera: Each lattice point corresponds to the 2 qubits intersecting at that point.
+    - Pegasus: Not Implemented
+    """
+    graph_data = G.graph
+
+    family = graph_data.get("family")
+    t = graph_data.get("tile")
+
+    if family == "chimera":
+        intersection_points = defaultdict(set)
+        if graph_data["labels"] == "coordinate":
+            for v in G:
+                _chimera_all_intersection_points(intersection_points, v, t, *v)
+
+        elif graph_data["data"]:
+            for v in G:
+                _chimera_all_intersection_points(
+                    intersection_points, v, t, *G.nodes[v]["chimera_index"])
+
+        else:
+            raise NotImplementedError(
+                "Please pass in a coordinated Chimera, or one where data=True.")
+
+        return intersection_points
+
+    elif family == "pegasus":
+        raise NotImplementedError("Pegasus forthcoming.")
+    return None
+
+
+def _chimera_all_intersection_points(intersection_points, v, t, i, j, u, k):
+    """
+    Given a coordinate vertex, v = (i, j, u, k), of a Chimera with tile, t, get all intersection points it is in.
+    """
+    # If you're a row vertex, you go in all grid points of your row intersecting columns in your unit tile
+    if u == 1:
+        row = i*t + k
+        for kk in range(t):
+            col = j*t + kk
+            intersection_points[(col, row)].add(v)
+
+    # Sameish for a column vertex.
+    elif u == 0:
+        col = j*t + k
+        for kk in range(t):
+            row = i*t + kk
+            intersection_points[(col, row)].add(v)
+
+
 def closest(S_layout, T_layout, subset_size=(1, 1), num_neighbors=1, **kwargs):
     """
     Maps vertices of S to the closest vertices of T as given by S_layout and T_layout. i.e. For each vertex u in

--- a/minorminer/layout/placement.py
+++ b/minorminer/layout/placement.py
@@ -90,7 +90,7 @@ def _intersection_binning(S_layout, T, scale_ratio):
     # --- Map the S_layout to the grid
     # "Zoom in" on layout_S so that the integer points are better represented
     if scale_ratio:
-        S_layout.scale = scale_ratio*scale
+        S_layout.scale = min(scale_ratio*scale, scale)
     else:
         S_layout.scale *= t
 
@@ -108,8 +108,8 @@ def _intersection_binning(S_layout, T, scale_ratio):
 def _lookup_intersection_coordinates(G):
     """
     For a dwave_networkx graph G, this returns a dictionary mapping the lattice points to sets of vertices of G. 
-    - Chimera: Each lattice point corresponds to the 2 qubits intersecting at that point.
-    - Pegasus: Not Implemented
+        - Chimera: Each lattice point corresponds to the 2 qubits intersecting at that point.
+        - Pegasus: Not Implemented
     """
     graph_data = G.graph
 
@@ -135,7 +135,6 @@ def _lookup_intersection_coordinates(G):
 
     elif family == "pegasus":
         raise NotImplementedError("Pegasus forthcoming.")
-    return None
 
 
 def _chimera_all_intersection_points(intersection_points, v, t, i, j, u, k):

--- a/minorminer/layout/tests/common.py
+++ b/minorminer/layout/tests/common.py
@@ -17,6 +17,8 @@ class TestLayoutPlacement(unittest.TestCase):
         self.G = nx.Graph()
         self.H = nx.complete_graph(1)
         self.C = dnx.chimera_graph(4)
+        self.C_coord = dnx.chimera_graph(4, coordinates=True)
+        self.C_blank = dnx.chimera_graph(4, data=False)
         self.P = dnx.pegasus_graph(4)
 
         # Compute some layouts
@@ -24,7 +26,10 @@ class TestLayoutPlacement(unittest.TestCase):
         self.S_small_layout = mml.Layout(self.S_small)
         self.G_layout = mml.Layout(self.G)
         self.C_layout = mml.Layout(self.C)
+        self.C_coord_layout = mml.Layout(self.C_coord)
+        self.C_blank_layout = mml.Layout(self.C_blank)
         self.C_layout_3 = mml.Layout(self.C, dim=3)
+        self.P_layout = mml.Layout(self.P)
 
     def assertArrayEqual(self, a, b):
         """

--- a/minorminer/layout/tests/test_find_embedding.py
+++ b/minorminer/layout/tests/test_find_embedding.py
@@ -91,6 +91,12 @@ class TestFindEmb(TestLayoutPlacement):
         mml.find_embedding(self.S, self.C, placement=mml.closest,
                            subset_size=subset_size, num_neighbors=num_neighbors)
 
+    def test_placement_interesction(self):
+        """
+        Test the intersection placement strategy
+        """
+        mml.find_embedding(self.S, self.C, placement=mml.intersection)
+
     def test_layout_parameter(self):
         """
         It can be a function or a 2-tuple of various things.

--- a/minorminer/layout/tests/test_placement.py
+++ b/minorminer/layout/tests/test_placement.py
@@ -2,14 +2,54 @@ import random
 import unittest
 
 import dwave_networkx as dnx
-import networkx as nx
-
 import minorminer.layout as mml
-from minorminer.layout.placement import _parse_layout
+import networkx as nx
+from minorminer.layout.placement import (_lookup_intersection_coordinates,
+                                         _parse_layout)
+
 from .common import TestLayoutPlacement
 
 
 class TestPlacement(TestLayoutPlacement):
+    def test_intersection(self):
+        """
+        Tests the intersection placement strategy.
+        """
+        # Default behavior
+        S_layout = mml.Layout(self.S)
+        placement = mml.intersection(S_layout, self.C_layout)
+        self.assertIsPlacement(self.S, self.C, placement)
+
+        # Test different scale ratios
+        S_layout = mml.Layout(self.S)
+        placement_1 = mml.intersection(
+            S_layout, self.C_layout, scale_ratio=.5)
+        S_layout = mml.Layout(self.S)
+        placement_2 = mml.intersection(
+            S_layout, self.C_layout, scale_ratio=1)
+        S_layout = mml.Layout(self.S)
+        placement_3 = mml.intersection(
+            S_layout, self.C_layout, scale_ratio=1.5)
+        self.assertIsPlacement(self.S, self.C, placement_1)
+        self.assertIsPlacement(self.S, self.C, placement_2)
+        self.assertIsPlacement(self.S, self.C, placement_3)
+
+        # Test a coordinate version of chimera
+        S_layout = mml.Layout(self.S)
+        placement = mml.intersection(S_layout, self.C_coord_layout)
+        self.assertIsPlacement(self.S, self.C_coord, placement)
+
+        # Test bad inputs
+        # Pegasus is not allowed
+        self.assertRaises(NotImplementedError, mml.intersection,
+                          self.S_layout, self.P_layout)
+        # Chimera must have data or coordinates
+        self.assertRaises(NotImplementedError, mml.intersection,
+                          self.S_layout, self.C_blank_layout)
+        # Pegasus coordinates not implemented
+        self.assertRaises(NotImplementedError,
+                          _lookup_intersection_coordinates, self.P)
+
     def test_closest(self):
         """
         Tests the closest placement strategy.


### PR DESCRIPTION
The `intersection_placement` is introduced.

This is a placement strategy specifically for Chimera (it can be extended for Pegasus or any other grid-like graph if desired). It works roughly as follows:
- Qubit pairs of Chimera are mapped to points in an integer lattice using the row-tracks and column-tracks of Chimera.
- Vertices from `S` (the source graph) are mapped to the closest integer point using a previously computed layout of `S`.