### PR TITLE
Run doxygen on full include dir and provide full C documentation in RTD

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -771,7 +771,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../include ../include/find_embedding ../include/busclique
+INPUT                  = ../include 
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -802,7 +802,7 @@ FILE_PATTERNS          =
 # be searched for input files as well.
 # The default value is: NO.
 
-RECURSIVE              = NO
+RECURSIVE              = YES
 
 # The EXCLUDE tag can be used to specify files and/or directories that should be
 # excluded from the INPUT source files. This way you can easily exclude a

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -771,7 +771,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../include
+INPUT                  = ../include ../include/find_embedding ../include/busclique
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/docs/source/reference/cppdocs.rst
+++ b/docs/source/reference/cppdocs.rst
@@ -7,5 +7,6 @@ C++ Library
     :maxdepth: 2
 
     ../cpp/namespacelist
-    ../cpp/classlist
     ../cpp/filelist
+    ../cpp/classlist
+    ../cpp/structlist


### PR DESCRIPTION
Currently RTD generates and displays very partial C documentation:
![image](https://user-images.githubusercontent.com/34041130/97615759-f50f8f00-19d8-11eb-9e39-82117ae1a720.png)

This update runs doxygen on all files under /include and displays namespaces, classes, files, and structs:
![image](https://user-images.githubusercontent.com/34041130/97615926-22f4d380-19d9-11eb-93be-e329af27c331.png)
