### PR TITLE
Update cookie methods, sphinx, and breathe

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-breathe<4.13.0
+breathe>4.25.0
 sphinx-rtd-theme
-sphinx
+sphinx>=4.0.0,<5.0.0
 cython>=0.28.5

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -140,8 +140,8 @@ html_static_path = ['_static']
 
 
 def setup(app):
-    app.add_stylesheet('cookie_notice.css')
-    app.add_javascript('cookie_notice.js')
+    app.add_css_file('cookie_notice.css')
+    app.add_js_file('cookie_notice.js')
     app.add_config_value('target', 'repo', 'env')
 
 # Configuration for intersphinx.


### PR DESCRIPTION
`app.add_stylesheet()` and `app.add_javascript()` were renamed in version 1.8 and obsoleted in version 4.
For updated sphinx, previous breathe produces `ModuleNotFoundError: No module named sphinx.ext.mathbase' error that was fixed in breathe ~4.25. 