### PR TITLE
Fix, and deprecate matlab support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,8 +129,14 @@ A more fleshed out example can be found under `examples/fourcolor.py`
     pip install -r requirements.txt
     python fourcolor.py
 
-Matlab
-======
+Matlab (Deprecated)
+===================
+
+Matlab support is deprecated as of vesion 0.2.8, and we will not accept bug reports
+in later versions.  The matlab interface has been broken for the entire 0.2 series,
+and more than a year passed before this was discovered.  It will be fixed in the 
+0.2.8 release, but the matlab support infrastructure will be removed entirely in
+May 2023, unless community developers volunteer to maintain it.
 
 Installation
 ------------

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -21,8 +21,9 @@ class MyCppInteractions : public find_embedding::LocalInteraction {
     void cancel() { _canceled = true; }
 
   private:
-    virtual void displayOutputImpl(const std::string& mess) const { std::cout << mess << std::endl; }
-    virtual bool cancelledImpl() const { return _canceled; }
+    void displayOutputImpl(int, const std::string& mess) const override { std::cout << mess << std::endl; }
+    void displayErrorImpl(int, const std::string& mess) const override { std::cerr << mess << std::endl; }
+    bool cancelledImpl() const override { return _canceled; }
 };
 
 int main() {

--- a/include/find_embedding/find_embedding.hpp
+++ b/include/find_embedding/find_embedding.hpp
@@ -85,8 +85,8 @@ class parameter_processor {
 
     vector<int> _filter_fixed_vars() {
         vector<int> unscrew(num_vars);
-        assert(var_fixed_unscrewed.size() == num_vars);
-        assert(num_fixed < num_vars);
+        minorminer_assert(var_fixed_unscrewed.size() == num_vars);
+        minorminer_assert(num_fixed < num_vars);
         for (unsigned int i = 0, front = 0, back = num_vars - num_fixed; i < num_vars; i++) {
             if (var_fixed_unscrewed[i]) {
                 unscrew[back++] = i;

--- a/matlab/find_embedding.cpp
+++ b/matlab/find_embedding.cpp
@@ -122,6 +122,13 @@ class LocalInteractionMATLAB : public find_embedding::LocalInteraction {
     }
 };
 
+void raiseWarning() {
+    mexWarnMsgIdAndTxt(
+        "MinorMiner:DeprecatedMEX",
+        "MEX support for minorminer is deprecated as of version 0.2.7, and will be removed entirely in December 2022"
+    );
+}
+
 void checkFindEmbeddingParameters(const mxArray* paramsArray,
                                   find_embedding::optional_parameters& findEmbeddingExternalParams) {
     // mxIsEmpty(paramsArray) handles the case when paramsArray is: struct('a', {}), since isempty(struct('a', {})) is
@@ -245,6 +252,8 @@ void checkFindEmbeddingParameters(const mxArray* paramsArray,
 
 // problem, A, params
 void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
+    raiseWarning();
+
     if (nrhs != 3) mexErrMsgTxt("Wrong number of arguments");
 
     if (nlhs > 2) mexErrMsgTxt("Too many outputs");

--- a/matlab/find_embedding.cpp
+++ b/matlab/find_embedding.cpp
@@ -102,17 +102,17 @@ void parseChainArray(const mxArray* a, const char* errorMsg, std::map<int, std::
 
 class LocalInteractionMATLAB : public find_embedding::LocalInteraction {
   private:
-    virtual void displayOutputImpl(const std::string& msg) const {
+    void displayOutputImpl(int, const std::string& msg) const override {
         mexPrintf("%s", msg.c_str());
         mexEvalString("drawnow;");
     }
 
-    virtual void displayErrorImpl(const std::string& msg) const {
+    void displayErrorImpl(int, const std::string& msg) const override {
         mexPrintf("%s", msg.c_str());
         mexEvalString("drawnow;");
     }
 
-    virtual bool cancelledImpl() const {
+    bool cancelledImpl() const override {
         if (utIsInterruptPending()) {
             utSetInterruptPending(false);
             return true;
@@ -276,7 +276,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
 
         result = find_embedding::findEmbedding(Qg, Ag, findEmbeddingExternalParams, chains);
     } catch (const find_embedding::MinorMinerException& e) {
-        mexErrMsgTxt(e.what().c_str());
+        mexErrMsgTxt(e.what());
     } catch (...) {
         mexErrMsgTxt("unknown error");
     }

--- a/matlab/make.m
+++ b/matlab/make.m
@@ -12,4 +12,4 @@
 %    See the License for the specific language governing permissions and
 %    limitations under the License.
 
-mex find_embedding.cpp -I../include CXXFLAGS="-std=c++1y -fPIC -O3" -lut -largeArrayDims -v
+mex find_embedding.cpp -I../include -I../include/find_embedding CXXFLAGS="-std=c++1y -fPIC -O3" -lut -largeArrayDims -v


### PR DESCRIPTION
The matlab interface has been broken since version 0.2.0, and nobody reported that for over a year.  I'm fixing this today in response to a support request, since we do advertise support in the readme.  However, the rest of Ocean does not support matlab, and we've decided to discontinue support in minorminer.  If a silent community of matlab users comes out of the woodwork and offers to provide this support, we'll consider it.