### PR TITLE
Introduce utils.zephyr module

### DIFF
--- a/minorminer/utils/pegasus.py
+++ b/minorminer/utils/pegasus.py
@@ -14,7 +14,6 @@
 #
 # ================================================================================================
 
-from dwave_networkx.generators.chimera import chimera_graph
 from dwave_networkx.generators.pegasus import (get_tuple_defragmentation_fn, fragmented_edges,
     pegasus_coordinates, pegasus_graph)
 from minorminer.utils.polynomialembedder import processor

--- a/minorminer/utils/tests/test_zephyr.py
+++ b/minorminer/utils/tests/test_zephyr.py
@@ -1,0 +1,197 @@
+# Copyright 2022 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# ================================================================================================
+
+import unittest
+from random import shuffle
+
+from dwave_networkx.generators.zephyr import zephyr_graph
+import networkx as nx
+from parameterized import parameterized
+
+from minorminer.utils.diagnostic import is_valid_embedding
+from minorminer.utils.zephyr import find_clique_embedding, find_biclique_embedding
+
+
+class Test_find_clique_embedding(unittest.TestCase):
+    def test_k_parameter_int(self):
+        k_int = 5
+        m = 3
+
+        # Find embedding
+        ze = zephyr_graph(m, coordinates=True)
+        embedding = find_clique_embedding(k_int, target_graph=ze)
+
+        self.assertTrue(is_valid_embedding(embedding, nx.complete_graph(k_int), ze))
+
+    def test_k_parameter_list(self):
+        k_nodes = ['one', 'two', 'three']
+        m = 4
+
+        # Find embedding
+        ze = zephyr_graph(m, coordinates=True)
+        embedding = find_clique_embedding(k_nodes, target_graph=ze)
+
+        self.assertTrue(is_valid_embedding(embedding, nx.complete_graph(k_nodes), ze))
+
+    def test_k_parameter_graph(self):
+        k_graph = nx.complete_graph(10)
+        m = 4
+
+        # Find embedding
+        ze = zephyr_graph(m, coordinates=True)
+        embedding = find_clique_embedding(k_graph, target_graph=ze)
+
+        self.assertTrue(is_valid_embedding(embedding, nx.complete_graph(k_graph), ze))
+
+    def test_zero_clique(self):
+        k = 0
+        m = 3
+
+        # Find embedding
+        ze = zephyr_graph(m)
+        embedding = find_clique_embedding(k, target_graph=ze)
+
+        self.assertEqual(k, len(embedding))
+        self.assertEqual({}, embedding)
+
+    def test_one_clique(self):
+        k = 1
+        m = 4
+
+        # Find embedding
+        ze = zephyr_graph(m, coordinates=True)
+        embedding = find_clique_embedding(k, target_graph=ze)
+
+        self.assertTrue(is_valid_embedding(embedding, nx.complete_graph(k), ze))
+
+    def test_valid_clique_ints(self):
+        k = nx.complete_graph(15)
+        m = 4
+
+        # Find embedding
+        ze = zephyr_graph(m)
+        embedding = find_clique_embedding(k, target_graph=ze)
+
+        self.assertTrue(is_valid_embedding(embedding, k, ze))
+
+    def test_valid_clique_coord(self):
+        k = nx.complete_graph(15)
+        m = 4
+
+        # Find embedding
+        ze = zephyr_graph(m, coordinates=True)
+        embedding = find_clique_embedding(k, target_graph=ze)
+
+        self.assertTrue(is_valid_embedding(embedding, k, ze))
+
+    def test_impossible_clique(self):
+        k = 55
+        m = 2
+
+        # Find embedding
+        ze = zephyr_graph(m)
+
+        with self.assertRaises(ValueError):
+            find_clique_embedding(k, target_graph=ze)
+
+    def test_clique_incomplete_graph(self):
+        k = 5
+        m = 2
+
+        # Nodes in a known K5 embedding
+        # Note: {0: (16, 96), 1: (18, 98), 2: (20, 100), 3: (22, 102), 4: (24, 104)}
+        known_embedding_nodes = {16, 96, 18, 98, 20, 100, 22, 102, 24, 104}
+
+        # Create graph with missing nodes
+        incomplete_ze = zephyr_graph(m)
+        removed_nodes = set(incomplete_ze.nodes) - known_embedding_nodes
+        incomplete_ze.remove_nodes_from(removed_nodes)
+
+        # See if clique embedding is found
+        embedding = find_clique_embedding(k, target_graph=incomplete_ze)
+        self.assertTrue(is_valid_embedding(embedding, nx.complete_graph(k), incomplete_ze))
+
+    def test_clique_missing_edges(self):
+        k = 9
+        m = 2
+
+        ze = zephyr_graph(m)
+
+        # pick a random ordering of the edges
+        edges = list(ze.edges())
+        shuffle(edges)
+
+        K = nx.complete_graph(k)
+
+        # now delete edges, one at a time, until we can no longer embed K
+        with self.assertRaises(ValueError):
+            while 1:
+                (u, v) = edges.pop()
+                ze.remove_edge(u, v)
+
+                # See if clique embedding is found
+                embedding = find_clique_embedding(k, target_graph=ze)
+                self.assertTrue(is_valid_embedding(embedding, K, ze))
+
+
+class Test_find_biclique_embedding(unittest.TestCase):
+    ABC_DE = (['a', 'b', 'c'], ['d', 'e'], 2)
+    ABC_P = (['a', 'b', 'c'], 7, 2)
+    N_DE = (4, ['d', 'e'], 2)
+
+    @parameterized.expand(((6, 6, 2), (16, 16, 3), (4, 5, 1), ABC_DE, ABC_P, N_DE))
+    def test_success(self, a, b, m):
+        left, right = find_biclique_embedding(a, b, m)
+
+        # check that labels match args
+        for arg, map_ in ((a, left), (b, right)):
+            if isinstance(arg, int):
+                self.assertEqual(len(map_), arg)
+            else:
+                self.assertEqual(set(map_), set(arg))
+
+        # check that labels are disjoint
+        self.assertEqual(set(left) | set(right), set(left) ^ set(right))
+
+        # check that the embedding is valid
+        ze = zephyr_graph(m)
+        biclique = nx.complete_bipartite_graph(left, right)
+        self.assertTrue(is_valid_embedding({**left, **right}, biclique, ze))
+
+    @parameterized.expand((((1, 2), (2, 3)), ((1, 2), 2), (3, (2, 3)), (('a', 'b'), ('b', 'c'))))
+    def test_overlapping_labels(self, a, b):
+        m = 2
+
+        # Find embedding
+        ze = zephyr_graph(m)
+
+        with self.assertRaises(ValueError):
+            find_biclique_embedding(a, b, target_graph=ze)
+
+    def test_impossible_biclique(self):
+        a = 25
+        b = 30
+        m = 2
+
+        # Find embedding
+        ze = zephyr_graph(m)
+
+        with self.assertRaises(ValueError):
+            find_biclique_embedding(a, b, target_graph=ze)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/minorminer/utils/zephyr.py
+++ b/minorminer/utils/zephyr.py
@@ -1,0 +1,134 @@
+# Copyright 2022 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# ================================================================================================
+
+from dwave_networkx.generators.zephyr import zephyr_graph
+import networkx as nx
+
+from minorminer.busclique import busgraph_cache
+
+__all__ = ['find_clique_embedding', 'find_biclique_embedding']
+
+
+def _get_target_graph(m=None, target_graph=None):
+    if target_graph is None:
+        if m is None:
+            raise TypeError("m and target_graph cannot both be None.")
+        target_graph = zephyr_graph(m)
+    return target_graph
+
+
+@nx.utils.decorators.nodes_or_number(0)
+def find_clique_embedding(k, m=None, target_graph=None):
+    """Find an embedding for a clique in a Zephyr graph.
+
+    Given a clique (fully connected graph) and target Zephyr graph, attempts
+    to find an embedding.
+
+    Args:
+        k (int/iterable/:obj:`networkx.Graph`): A complete graph to embed,
+            formatted as a number of nodes, node labels, or a NetworkX graph.
+
+        m (int): Number of tiles in a row of a square Zephyr graph.  Required
+            to generate an ``m``-by-``m`` Zephyr graph when ``target_graph`` is None.
+
+        target_graph (:obj:`networkx.Graph`): A Zephyr graph.  Required when
+            ``m`` is None.
+
+    Returns:
+        dict: An embedding as a dict, where keys represent the clique's nodes
+        and values, formatted as lists, represent chains of zephyr coordinates.
+
+    Examples:
+        This example finds an embedding for a :math:`K_5` complete graph in a
+        2-by-2 Zephyr graph.
+
+        >>> from dwave.embedding.zephyr import find_clique_embedding
+        >>> find_clique_embedding(5, 2)
+        {0: (16, 96), 1: (18, 98), 2: (20, 100), 3: (22, 102), 4: (24, 104)}
+    """
+    _, nodes = k
+    g = _get_target_graph(m, target_graph)
+    embedding = busgraph_cache(g).find_clique_embedding(nodes)
+
+    if len(embedding) != len(nodes):
+        raise ValueError("No clique embedding found")
+
+    return embedding
+
+
+@nx.utils.decorators.nodes_or_number(0)
+@nx.utils.decorators.nodes_or_number(1)
+def find_biclique_embedding(a, b, m=None, target_graph=None):
+    """Find an embedding for a biclique in a Zephyr graph.
+
+    Given a biclique (a bipartite graph where every vertex in a set in
+    connected to all vertices in the other set) and a target :term:`Zephyr`
+    graph, attempts to find an embedding.
+
+    Args:
+        a (int/iterable):
+            Describes the left shore of the biclique to embed.  If ``a`` is an
+            integer, the left shore will be labelled [0, a-1].  If ``a`` is an
+            iterable, the left shore will be labelled by ``a``.
+
+        b (int/iterable):
+            Describes the right shore of the biclique to embed.  If ``b`` is an
+            integer and ``a`` is an iterable, the right shore will be labelled
+            [0, b-1].  If both ``a`` and ``b`` are integers, the right shore
+            will be labelled [a, a+b-1].  If ``b`` is an iterable, the right
+            shore will be labelled by ``b``.
+
+        m (int): Number of tiles in a row of a square Zephyr graph.  Required to
+            generate an ``m``-by-``m`` Zephyr graph when ``target_graph`` is None.
+
+        target_graph (:obj:`networkx.Graph`): A Zephyr graph.  Required when ``m``
+            is None.
+
+    Returns:
+        tuple: A 2-tuple containing:
+
+            dict: An embedding mapping the left shore of the biclique to
+            the Zephyr lattice.
+
+            dict: An embedding mapping the right shore of the biclique to
+            the Zephyr lattice.
+
+    Examples:
+        This example finds an embedding for an alphanumerically labeled
+        biclique in a 2x2 Zephyr graph.
+
+        >>> from dwave.embedding.zephyr import find_biclique_embedding
+        >>> left, right = find_biclique_embedding(['a', 'b', 'c'], ['d', 'e'], 2)
+        >>> print(left, right)
+        {'a': (0,), 'b': (4,), 'c': (8,)} {'d': (80,), 'e': (84,)}
+    """
+    _a, anodes = a
+    _b, bnodes = b
+
+    if isinstance(_a, int) and isinstance(_b, int):
+        bnodes = [len(anodes) + x for x in bnodes]
+
+    if set(anodes).intersection(set(bnodes)):
+        raise ValueError("a and b overlap")
+
+    g = _get_target_graph(m, target_graph)
+    embedding = busgraph_cache(g).find_biclique_embedding(len(anodes), len(bnodes))
+
+    if not embedding:
+        raise ValueError("No biclique embedding found")
+
+    return ({x: embedding[anodes.index(x)] for x in anodes},
+            {y: embedding[bnodes.index(y) + len(anodes)] for y in bnodes})

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,3 @@
 pytest>=6.0.0
 pytest-subtests
+parameterized==0.7.4


### PR DESCRIPTION
The `utils.zephyr` module provides the same interface as the `utils.pegasus` module, but has a more modern implementation based on the `busclique` module.

The `utils.zephyr.find_biclique_embedding` function is subject to additional unit tests as compared to `utils.chimera.find_biclique_embedding` and `utils.pegasus.find_biclique_embedding`.

In the future, the three `utils.<topology>` modules could be united to use a single implementation, but that is not attempted at this time.

See also https://github.com/dwavesystems/dwave-system/pull/448.  That PR will be updated to use this module once this PR has been merged and a new version of `minorminer` is released.