### PR TITLE
Add clique cache mining and manipulation functions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ build_script:
 
 test_script:
   # Run the project tests
-  - "%PYTHON%\\python.exe -m pytest . --verbose"
+  - "%PYTHON%\\python.exe -m pytest . --verbose --log-cli-level=INFO"
 
 after_test:
   # If tests are successful, create binary packages for the project.

--- a/include/busclique/coordinate_types.hpp
+++ b/include/busclique/coordinate_types.hpp
@@ -282,6 +282,21 @@ constexpr size_w operator""_w(unsigned long long int v) { return static_cast<siz
 //! user-defined literal for size_z
 constexpr size_z operator""_z(unsigned long long int v) { return static_cast<size_t>(v); }
 
+// These are for convenience, and probably belong in their own file...
+
+//! user-defined literal for uint64_t
+constexpr uint64_t operator""_u64(unsigned long long int v) { return static_cast<uint64_t>(v); }
+
+//! user-defined literal for uint32_t
+constexpr uint32_t operator""_u32(unsigned long long int v) { return static_cast<uint32_t>(v); }
+
+//! user-defined literal for uint16_t
+constexpr uint16_t operator""_u16(unsigned long long int v) { return static_cast<uint16_t>(v); }
+
+//! user-defined literal for uint8_t
+constexpr uint8_t operator""_u8(unsigned long long int v) { return static_cast<uint8_t>(v); }
+
+
 //! An arena to perform arithmetic that does not respect the unit system defined
 //! in coordinate_base<T>.  This class is not a friend of coordinate_base<T> so
 //! so that we can do all of our bounds-checking here, with full type-safety.

--- a/minorminer/busclique.pyx
+++ b/minorminer/busclique.pyx
@@ -331,7 +331,7 @@ class busgraph_cache:
             if length not in by_length or len(raw[by_length[length]]) < len(emb):
                 by_length[length] = key
             if write_to_disk:
-                self._fetch_cache('clique', lambda: cache, force_write=True)
+                self._fetch_cache('clique', lambda: self._cliques, force_write=True)
         else:
             max_length = max(map(len, emb)) if emb else 0
             emb_list = [[c for c in emb if len(c) <= i] for i in range(max_length+1)]
@@ -434,7 +434,7 @@ class busgraph_cache:
         `self.graph` has the filename `str(shortcode)` -- this is preferable to
         using a single file to store the entire cache.  In the case of hash
         collisions, the databases of multiple graphs will be stored in a single
-        cache file -- so that file contains a `json`'d dict mapping
+        cache file -- so that file contains a `pickle`'d dict mapping
         indentifiers (not shortcodes) to the corresponding clique/biclique
         caches.
 

--- a/minorminer/busclique.pyx
+++ b/minorminer/busclique.pyx
@@ -25,7 +25,8 @@ import random
 import gzip
 from pickle import dump, load
 from json import dumps, loads
-import networkx as nx, dwave_networkx as dnx
+import networkx as nx
+import dwave_networkx as dnx
 from itertools import zip_longest
 
 
@@ -64,25 +65,25 @@ def _num_nodes(nn, offset = 0):
 
 _no_seed = object()
 def find_clique_embedding(nodes, g, seed = _no_seed, use_cache = True):
-    """Finds a clique embedding in the graph ``g`` using a polynomial-time 
+    """Finds a clique embedding in the graph ``g`` using a polynomial-time
     algorithm.
 
     Args:
-        nodes (int/iterable): 
-            A number (indicating the size of the desired clique) or an 
+        nodes (int/iterable):
+            A number (indicating the size of the desired clique) or an
             iterable (specifying the node labels of the desired clique).
-        
-        g (NetworkX Graph): 
-            The target graph that is either a :func:`dwave_networkx.chimera_graph` 
+
+        g (NetworkX Graph):
+            The target graph that is either a :func:`dwave_networkx.chimera_graph`
             or :func:`dwave_networkx.pegasus_graph`.
-        
+
         use_cache (bool, optional, default=True):
-            Whether or not to compute/restore a cache of clique embeddings for 
-            ``g``. Note that this function only uses the filesystem cache, and 
-            does not maintain the cache in memory. If many (or even several) 
-            embeddings are desired in a single session, it is recommended to use 
+            Whether or not to compute/restore a cache of clique embeddings for
+            ``g``. Note that this function only uses the filesystem cache, and
+            does not maintain the cache in memory. If many (or even several)
+            embeddings are desired in a single session, it is recommended to use
             :class:`.busgraph_cache`.
-            
+
         seed (int, optional):
             A seed for an internal random number generator.  If ``use_cache`` is
             True, then the seed defaults to an internally-defined value which
@@ -90,24 +91,24 @@ def find_clique_embedding(nodes, g, seed = _no_seed, use_cache = True):
             current python random state.
 
     Returns:
-        dict: An embedding of node labels (either nodes, or range(nodes)) mapped 
+        dict: An embedding of node labels (either nodes, or range(nodes)) mapped
         to chains of a clique embedding.
 
     Note:
         Due to internal optimizations, not all Chimera graphs are supported by
         this code. Specifically, the graphs :func:`dwave_networkx.chimera_graph(m, n, t)`
-        are only supported for :math:`t<=8`. The code currently supports D-Wave 
-        products, which have :math:`t=4`, but not all graphs. For graphs with 
+        are only supported for :math:`t<=8`. The code currently supports D-Wave
+        products, which have :math:`t=4`, but not all graphs. For graphs with
         :math:`t>8`, use the legacy chimera-embedding package.
 
     Note:
         When the cache is used, clique embeddings of all sizes are computed
         and cached. This takes somewhat longer than a single embedding, but tends
-        to pay off after a fairly small number of calls. An exceptional use case 
-        is when there are a large number of missing internal couplers, where the 
-        result is nondeterministic -- avoiding the cache in this case may be 
+        to pay off after a fairly small number of calls. An exceptional use case
+        is when there are a large number of missing internal couplers, where the
+        result is nondeterministic -- avoiding the cache in this case may be
         preferable.
-    
+
     """
     try:
         graphdata = g.graph
@@ -131,11 +132,11 @@ def find_clique_embedding(nodes, g, seed = _no_seed, use_cache = True):
         return busgraph(g, seed=seed).find_clique_embedding(nodes)
 
 class busgraph_cache:
-    """A cache class for Chimera, Pegasus and Zephyr graphs, and their 
+    """A cache class for Chimera, Pegasus and Zephyr graphs, and their
     associated cliques and bicliques.
 
     The cache files are stored in a directory determined by `homebase` (use
-    :meth:`busgraph_cache.cache_rootdir` to retrieve the path to this directory). 
+    :meth:`busgraph_cache.cache_rootdir` to retrieve the path to this directory).
     Subdirectories named `cliques` and `bicliques` are then created to store the
     respective caches in each.
 
@@ -146,10 +147,10 @@ class busgraph_cache:
     Note:
         Due to internal optimizations, not all Chimera graphs are supported by
         this code. Specifically, the graphs :func:`dwave_networkx.chimera_graph(m, n, t)`
-        are only supported for :math:`t<=8`. The code currently supports D-Wave 
-        products, which have :math:`t=4`, but not all graphs. For graphs with 
+        are only supported for :math:`t<=8`. The code currently supports D-Wave
+        products, which have :math:`t=4`, but not all graphs. For graphs with
         :math:`t>8`, use the legacy chimera-embedding package.
-    
+
     """
     def __init__(self, g, seed = 0):
         self._family = g.graph['family']
@@ -223,11 +224,11 @@ class busgraph_cache:
 
     def get_clique_cache(self, sparse=False, compress=True):
         """Returns an object representing the cliques stored in this cache.
-        
+
         Args:
             sparse: (bool, optional, default=False)
                 If True, the cache will be a dictionary mapping embedding sizes
-                to lists of chains.  Otherwise, the cache will be a list of 
+                to lists of chains.  Otherwise, the cache will be a list of
                 lists of chains; the index of the outermost list corresponding
                 to embedding size.
 
@@ -253,7 +254,7 @@ class busgraph_cache:
     def update_clique_cache(self, cache, write_to_disk = True):
         """Replaces or sets the cliques stored by this cache with the provided
         cache object.
-        
+
         Args:
             cache: (bytes, str, dict or iterable)
                 The cache object to replace.  Should be an object returned by
@@ -279,7 +280,7 @@ class busgraph_cache:
 
     def insert_clique_embedding(self, emb, write_to_disk=True, quality_function=None, direct=False):
         """Inserts a clique embedding into the cache.
-        
+
         Args:
             emb: (dict or list)
                 The embedding to insert into the cache.
@@ -300,7 +301,7 @@ class busgraph_cache:
                 If True, the embedding will be stored directly into the cache,
                 overwriting the current clique of that size if it exists.  In
                 this case, ``quality_function`` must be ``None``.
-                Otherwise, the embedding and embeddings derived by removing 
+                Otherwise, the embedding and embeddings derived by removing
                 chains in decreasing order of length may be stored into the
                 cache, if ``quality function`` evaluated on the new embedding is
                 greater than the old.  If ``quality_function`` is None, new
@@ -326,12 +327,14 @@ class busgraph_cache:
             if write_to_disk:
                 self._fetch_cache('clique', lambda: cache, force_write=True)
         else:
-            cache = _make_clique_cache([emb])
+            max_length = max(map(len, emb)) if emb else 0
+            emb_list = [[c for c in emb if len(c) <= i] for i in range(max_length+1)]
+            cache = _make_clique_cache(emb_list)
             self.merge_clique_cache(cache, quality_function, write_to_disk)
 
     def merge_clique_cache(self, cache, quality_function=None, write_to_disk=True):
         """Merges the clique cache of another ``busgraph_cache`` object
-        
+
         Args:
             cache: (busgraph_cache or object)
                 If ``cache`` is a ``busgraph_cache``, its clique cache will be
@@ -358,7 +361,7 @@ class busgraph_cache:
         raw0 = cache['raw']
         raw1 = self._cliques['raw']
         used = {}
-        
+
         size = {}
         size0 = cache['size']
         size1 = self._cliques['size']
@@ -370,11 +373,13 @@ class busgraph_cache:
             elif key0 is None:
                 key = used.setdefault((key1, 1), len(used))
             else:
-                if quality_function is None:
+                if i == 0:
+                    qual0 = qual1 = 0
+                elif quality_function is None:
                     # by default, shortest chainlength is highest quality
-                    qual0 = -len(raw0[key0][i])
-                    qual1 = -len(raw1[key1][i])
-                else:                    
+                    qual0 = -len(raw0[key0][i-1])
+                    qual1 = -len(raw1[key1][i-1])
+                else:
                     qual0 = quality_function(raw0[key0][:i])
                     qual1 = quality_function(raw1[key1][:i])
                 if qual0 > qual1:
@@ -382,7 +387,7 @@ class busgraph_cache:
                 else:
                     # if the quality is the same, retain the old embedding
                     key = used.setdefault((key1, 1), len(used))
-            size[i] = key            
+            size[i] = key
 
         length = {}
         length0 = cache['length']
@@ -393,7 +398,7 @@ class busgraph_cache:
             if key1 is None:
                 key = used.setdefault((key0, 0), len(used))
             elif key0 is None:
-                key = used.setdefault((key1, 1), len(used))            
+                key = used.setdefault((key1, 1), len(used))
             elif len(raw0[key0]) > len(raw1[key1]):
                 # pick the larger embedding
                 key = used.setdefault((key0, 0), len(used))
@@ -411,7 +416,7 @@ class busgraph_cache:
         """This is an ad-hoc implementation of a file-cache using a LRU strategy.
         It's intended to be platform independent, thread- and multiprocess-safe,
         and reasonably performant -- I couldn't find a ready-made solution that
-        satisfies those requirements, so I had to roll my own.  TODO: keep 
+        satisfies those requirements, so I had to roll my own.  TODO: keep
         looking for something cleaner.
 
         We use `homebase` to locate a viable directory to store our caches.
@@ -441,7 +446,7 @@ class busgraph_cache:
         lrufile = os.path.join(basedir, ".lru")
         identifier = self._graph.identifier
         shortcode = self._graph.short_identifier
-        
+
         #this makes our writes to the filesystem atomic
         file_context = copy_on_close_context()
 
@@ -455,15 +460,15 @@ class busgraph_cache:
                         currcache = load(filecache)
                 else:
                     currcache = {}
-                cache = currcache.get(identifier)
-                if cache is None or force_write:
+                cache = None if force_write else currcache.get(identifier)
+                if cache is None:
                     cache = compute()
                     currcache[identifier] = cache
                     with file_context.open(cachefile, 'wb') as filecache:
                         dump(currcache, filecache)
 
                 #now, update the LRU cache -- if this was being done in-memory,
-                #there are more efficient algorithms... but since we're doing 
+                #there are more efficient algorithms... but since we're doing
                 #linear-time read&write, might as well do it the lazy way.
                 try:
                     with open(lrufile, 'rb') as lru:
@@ -489,14 +494,14 @@ class busgraph_cache:
 
     def largest_clique(self):
         """Returns the largest-found clique in the clique cache.
-        
-        This will compute the entire clique cache if it is missing from the 
+
+        This will compute the entire clique cache if it is missing from the
         filesystem.
 
         Returns:
-            dict: An embedding of node labels from ``range(len(embedding))`` 
+            dict: An embedding of node labels from ``range(len(embedding))``
             mapped to chains of the largest-found clique.
-        
+
         """
         self._ensure_clique_cache()
         embs = self._cliques['raw']
@@ -510,7 +515,7 @@ class busgraph_cache:
         """Returns the largest-found clique in the clique cache, with a specified
         maximum ``chainlength``.
 
-        This will compute the entire clique cache if it is missing from the 
+        This will compute the entire clique cache if it is missing from the
         filesystem.
 
         Args:
@@ -518,9 +523,9 @@ class busgraph_cache:
                 Max chain length.
 
         Returns:
-            dict: An embedding of node labels from ``range(len(embedding))`` 
+            dict: An embedding of node labels from ``range(len(embedding))``
             mapped to chains of the largest-found clique with maximum ``chainlength``.
-        
+
         """
         self._ensure_clique_cache()
         embs = self._cliques['raw']
@@ -532,21 +537,21 @@ class busgraph_cache:
             return {}
 
     def find_clique_embedding(self, nn):
-        """Returns a clique embedding, minimizing the maximum chainlength given 
+        """Returns a clique embedding, minimizing the maximum chainlength given
         its size.
-        
+
         This will compute the entire clique cache if it is missing from
         the filesystem.
-        
+
         Args:
             nn (int/iterable):
-                A number (indicating the size of the desired clique) or an 
+                A number (indicating the size of the desired clique) or an
                 iterable (specifying the node labels of the desired clique).
 
         Returns:
-            dict: An embedding of node labels (either ``nn``, or ``range(nn)``) 
+            dict: An embedding of node labels (either ``nn``, or ``range(nn)``)
             mapped to chains of a clique embedding.
-        
+
         """
         num, nodes = _num_nodes(nn)
         self._ensure_clique_cache()
@@ -561,15 +566,15 @@ class busgraph_cache:
     def largest_balanced_biclique(self):
         """Returns the largest-size biclique where both sides have equal size.
 
-        Nodes of the embedding dict are from ``range(len(embedding))``, where the 
-        nodes ``range(len(embedding)/2)`` are completely connected to the nodes 
+        Nodes of the embedding dict are from ``range(len(embedding))``, where the
+        nodes ``range(len(embedding)/2)`` are completely connected to the nodes
         ``range(len(embedding)/2, len(embedding))``.
 
         This will compute the entire biclique cache if it is missing from the
         filesystem.
 
         Returns:
-            dict: An embedding of node labels (described above) mapped to chains 
+            dict: An embedding of node labels (described above) mapped to chains
             of the largest balanced biclique.
 
         """
@@ -586,28 +591,28 @@ class busgraph_cache:
         return self._graph.relabel(dict(enumerate(emb0 + emb1)))
 
     def find_biclique_embedding(self, nn, mm):
-        """Returns a biclique embedding, minimizing the maximum chain length 
-        given its size. 
-        
-        This will compute the entire biclique cache if it is missing from the 
+        """Returns a biclique embedding, minimizing the maximum chain length
+        given its size.
+
+        This will compute the entire biclique cache if it is missing from the
         filesystem.
-        
+
         Args:
             nn (int/iterable):
-                A number (indicating the size of one side of the desired biclique) 
+                A number (indicating the size of one side of the desired biclique)
                 or an iterable (specifying the node labels of one side the desired
                 biclique).
 
             mm (int/iterable):
                 Same as ``nn``, for the other side of the desired biclique.
 
-        In the case that ``nn`` is a number, the first side will have nodes 
-        labeled from ``range(nn)``. In the case that ``mm`` is a number, the 
-        second side will have nodes labeled from ``range(n, n + mm)``; where 
+        In the case that ``nn`` is a number, the first side will have nodes
+        labeled from ``range(nn)``. In the case that ``mm`` is a number, the
+        second side will have nodes labeled from ``range(n, n + mm)``; where
         ``n`` is either ``nn`` or ``len(nn)``.
 
         Returns:
-            dict: An embedding of node labels (described above) mapped to chains 
+            dict: An embedding of node labels (described above) mapped to chains
             of a biclique embedding.
         """
         self._ensure_biclique_cache()
@@ -643,7 +648,7 @@ class busgraph_cache:
                     emb = dict(zip(N + M, emb1[:n] + emb0))
                 return self._graph.relabel(emb)
         return {}
-        
+
     def draw_fragment_embedding(self, emb, **kwargs):
         m, n, t, nodes, edges = self._graph.fragment_graph_spec()
 
@@ -657,7 +662,7 @@ class busgraph_cache:
 cdef dict _make_clique_cache(vector[embedding_t] &embs):
     """
     Process the raw clique cache produced by the c++ code.  Store both the raw
-    list of embeddings (a list `raw` with `raw[i]` being the maximum-size 
+    list of embeddings (a list `raw` with `raw[i]` being the maximum-size
     embedding with maximum chainlength `i`), and a size-indexed dictionary
     `by_size` where `embs[by_size[j]]` is a clique embedding of size `j` whose
     maximum chainlength is minimized.
@@ -789,13 +794,12 @@ cdef class _zephyr_busgraph:
     cdef readonly object short_identifier
     def __cinit__(self, g, seed = 0, compute_identifier = False):
         """
-        This is a class which manages a single zephyr graph, and dispatches 
+        This is a class which manages a single zephyr graph, and dispatches
         various structure-aware c++ embedding functions on it.
         """
         cdef size_t rows = g.graph['rows']
         cdef size_t cols = g.graph['columns']
         cdef size_t tile = g.graph['tile']
-        cdef str graph_id = g.graph.get('id')
         if tile > 4:
             raise NotImplementedError(("this clique embedder supports zephyr "
                                        "graphs with a tile size of 4 or less"))
@@ -827,16 +831,16 @@ cdef class _zephyr_busgraph:
         short_clique(zep[0], self.nodes, edges, self.emb_1)
 
         if compute_identifier:
-            if graph_id is None:
-                self.identifier, self.short_identifier = _serialize(self.topo, 'zephyr')
-            else:
-                self.short_identifier = "{}_{:x}".format(graph_id, internal_seed)
-                self.identifier = 0 # short_identifier is unique
+            self.identifier, self.short_identifier = _serialize(self.topo, 'zephyr')
 
         del zep
 
     def __dealloc__(self):
         del self.topo
+
+    def set_mask_bound(self, num_masks):
+        """Sets the maximum number of masks to consider."""
+        self.topo[0].set_mask_bound(num_masks)
 
     def bicliques(self):
         """
@@ -884,9 +888,9 @@ cdef class _zephyr_busgraph:
         nodes = self.topo.fragment_nodes()
         edges = self.topo.fragment_edges()
         return m, n, t, nodes, edges
-        
+
     def fragment_nodes(self, nodes = None):
-        if nodes is None:        
+        if nodes is None:
             return self.topo.fragment_nodes()
         else:
             return self.topo.topo.fragment_nodes(nodes)
@@ -901,13 +905,12 @@ cdef class _pegasus_busgraph:
     cdef readonly object short_identifier
     def __cinit__(self, g, seed = 0, compute_identifier = False):
         """
-        This is a class which manages a single pegasus graph, and dispatches 
+        This is a class which manages a single pegasus graph, and dispatches
         various structure-aware c++ embedding functions on it.
         """
         rows = g.graph['rows']
         voff = [o//2 for o in g.graph['vertical_offsets'][::2]]
         hoff = [o//2 for o in g.graph['horizontal_offsets'][::2]]
-        cdef str graph_id = g.graph.get('id')
 
         cdef uint32_t internal_seed
         if seed is None:
@@ -941,16 +944,16 @@ cdef class _pegasus_busgraph:
         short_clique(peg[0], self.nodes, edges, self.emb_1)
 
         if compute_identifier:
-            if graph_id is None:
-                self.identifier, self.short_identifier = _serialize(self.topo, 'pegasus')
-            else:
-                self.short_identifier = "{}_{}".format(graph_id, internal_seed)
-                self.identifier = 0 # short_identifier is unique
+            self.identifier, self.short_identifier = _serialize(self.topo, 'pegasus')
 
         del peg
 
     def __dealloc__(self):
         del self.topo
+
+    def set_mask_bound(self, num_masks):
+        """Sets the maximum number of masks to consider."""
+        self.topo[0].set_mask_bound(num_masks)
 
     def bicliques(self):
         """
@@ -1000,20 +1003,20 @@ cdef class _pegasus_busgraph:
         return m, n, t, nodes, edges
 
     def fragment_nodes(self, nodes = None):
-        if nodes is None:        
+        if nodes is None:
             return self.topo.fragment_nodes()
         else:
             return self.topo.topo.fragment_nodes(nodes)
 
 cdef class _chimera_busgraph:
-    """Class for managing a single Chimera graph, and dispatches various 
+    """Class for managing a single Chimera graph, and dispatches various
     structure-aware C++ embedding functions on it.
 
-    Note: 
+    Note:
         Due to internal optimizations, not all Chimera graphs are supported by
         this code. Specifically, the graphs :func:`dwave_networkx.chimera_graph(m, n, t)`
-        are only supported for :math:`t<=8`. The code currently supports D-Wave 
-        products, which have :math:`t=4`, but not all graphs. For graphs with 
+        are only supported for :math:`t<=8`. The code currently supports D-Wave
+        products, which have :math:`t=4`, but not all graphs. For graphs with
         :math:`t>8`, use the legacy chimera-embedding package.
     """
     cdef topo_cache[chimera_spec] *topo
@@ -1027,7 +1030,6 @@ cdef class _chimera_busgraph:
         rows = g.graph['rows']
         cols = g.graph['columns']
         tile = g.graph['tile']
-        cdef str graph_id = g.graph.get('id')
 
         if tile > 8:
             raise NotImplementedError(("this clique embedder supports chimera "
@@ -1059,17 +1061,17 @@ cdef class _chimera_busgraph:
         short_clique(chim[0], self.nodes, edges, self.emb_1)
 
         if compute_identifier:
-            if graph_id is None:
-                self.identifier, self.short_identifier = _serialize(self.topo, 'chimera')
-            else:
-                self.short_identifier = "{}_{}".format(graph_id, internal_seed)
-                self.identifier = 0 # short_identifier is unique
+            self.identifier, self.short_identifier = _serialize(self.topo, 'chimera')
 
         del chim
 
 
     def __dealloc__(self):
         del self.topo
+
+    def set_mask_bound(self, num_masks):
+        """Sets the maximum number of masks to consider."""
+        self.topo[0].set_mask_bound(num_masks)
 
     def bicliques(self):
         """
@@ -1119,15 +1121,109 @@ cdef class _chimera_busgraph:
         return m, n, t, nodes, edges
 
     def fragment_nodes(self, nodes = None):
-        if nodes is None:        
+        if nodes is None:
             return self.topo.fragment_nodes()
         else:
             return self.topo.topo.fragment_nodes(nodes)
 
+def _default_quality_function(emb):
+    maxlen = max(map(len, emb))
+    return -maxlen, sum(len(chain) == maxlen for chain in emb)
+
+def _regularize_embedding(g, emb):
+    progress = len(set(map(len, emb.values()))) != 1
+    max_length = max(map(len, emb.values()))
+    emb = {i: list(chain) for i, chain in emb.items()}
+    remainder = set(g) - set().union(*emb.values())
+    while progress:
+        matching_graph = nx.Graph()
+        top_nodes = []
+        for i, chain in emb.items():
+            if len(chain) == max_length:
+                continue
+            boundary = nx.node_boundary(g, chain, remainder)
+            for j in range(len(chain), max_length):
+                chain_node = (i, 'chain', j)
+                top_nodes.append(chain_node)
+                matching_graph.add_edges_from((chain_node, q) for q in boundary)
+        matching = nx.bipartite.maximum_matching(matching_graph, top_nodes)
+        for chain_node in top_nodes:
+            matched = matching.get(chain_node)
+            if matched is not None:
+                remainder.discard(matched)
+                progress = True
+                emb[chain_node[0]].append(matched)
+        if progress:
+            progress = len(set(map(len, emb.values()))) != 1
+    return {i: tuple(chain) for i, chain in emb.items()}
+
+def mine_clique_embeddings(
+        g,
+        heuristic_bound=None,
+        heuristic_args=None,
+        heuristic_runs=10,
+        mask_bound=64,
+        quality_function=None,
+        regularize=True,
+        num_seeds = 16
+    ):
+    from minorminer import miner
+    import logging
+    logger = logging.getLogger(__name__)
+    bgc = busgraph_cache(g)
+    bgc._graph.set_mask_bound(1)
+    bgc._ensure_clique_cache()
+    if heuristic_bound is None:
+        if bgc._family == "zephyr":
+            tile = g.graph['tile']
+            rows = g.graph['rows']
+            heuristic_bound = min(8*tile, 2*tile*(rows - 1))
+        elif bgc._family == "pegasus":
+            rows = g.graph['rows']
+            heuristic_bound = min(36, 12*(rows-1))
+        elif bgc._family == "chimera":
+            rows = g.graph['rows']
+            cols = g.graph['cols']
+            tile = g.graph['tile']
+            heuristic_bound = (min(tile*rows, tile*cols)+3)/4
+        else:
+            raise NotImplementedError("graph family not supported")
+
+    if quality_function is None:
+        quality_function = _default_quality_function
+
+    if heuristic_args is None:
+        heuristic_args = dict(chainlength_patience=100, max_beta=3, tries=1)
+
+    for size in range(3, heuristic_bound+1):
+        logger.info("running heuristic embeddings for size %d", size)
+        hm = miner(nx.complete_graph(size), g, **heuristic_args)
+        for emb in hm.find_embeddings(heuristic_runs, force=False):
+            if not emb:
+                continue
+            bgc.insert_clique_embedding(emb, write_to_disk=False, quality_function=quality_function)
+            if regularize:
+                emb1 = _regularize_embedding(g, emb)
+                bgc.insert_clique_embedding(emb1, write_to_disk=False, quality_function=quality_function)
+
+    for i in range(num_seeds):
+        logger.info("polynomial embedder run %d of %d", i+1, num_seeds)
+        seed = random.randint(0, 2**32-1)
+        bgc_i = busgraph_cache(g, seed=i)
+        bgc_i._graph.set_mask_bound(mask_bound)
+        bgc.merge_clique_cache(bgc_i, write_to_disk=False, quality_function=quality_function)
+        if regularize:
+            for n in range(3, len(bgc_i.largest_clique())+1):
+                emb = _regularize_embedding(g, bgc_i.find_clique_embedding(n))
+                bgc.insert_clique_embedding(emb, write_to_disk=False, quality_function=quality_function)
+
+    bgc.insert_clique_embedding({}, write_to_disk=True)
+    return bgc
+
 class copy_on_close_context:
     def __init__(self):
         self.files = {}
-        
+
     def open(self, file_name, mode):
         if file_name in self.files:
             self.files.clear()
@@ -1136,7 +1232,7 @@ class copy_on_close_context:
             temp_name = file_name + '~'
             file_obj = open(temp_name, mode)
             self.files[file_name] = temp_name, file_obj
-            return file_obj        
+            return file_obj
 
     def close(self):
         for file_name, (temp_name, file_obj) in self.files.items():

--- a/minorminer/busclique_h.pxi
+++ b/minorminer/busclique_h.pxi
@@ -72,6 +72,7 @@ cdef extern from "../include/busclique/topo_cache.hpp" namespace "busclique":
         size_t serialize[t](t, uint8_t *) const
         nodes_t fragment_nodes() const
         edges_t fragment_edges() const
+        void set_mask_bound(uint32_t)
 
 cdef extern from "../include/busclique/find_clique.hpp" namespace "busclique":
     int find_clique[T](topo_cache[T] &, size_t, embedding_t &)

--- a/tests/test_busclique.py
+++ b/tests/test_busclique.py
@@ -366,6 +366,64 @@ class TestBusclique(unittest.TestCase):
         #we merely got lucky hammering down the tet above
         self.assertEqual(None, find_nondeterminism('chimera', 4, 10))
 
+    def test_cache_export_import(self):
+        # make sure we're nondeterministic so accidentally re-computing the 
+        # cache will be detected
+        p4 = self.p4_nd[0]
+        bgc = busclique.busgraph_cache(p4, seed=100)
+        cliques = [bgc.find_clique_embedding(n) for n in range(len(bgc.largest_clique()))]
+        for sparse in (True, False):
+            for compress in (True, False):
+                with self.subTest(msg=f"sparse: {sparse}, compress: {compress}"):
+                    tmp = busclique.busgraph_cache(p4, seed=101)
+                    tmp.update_clique_cache([], write_to_disk=True)
+                    self.assertEqual(tmp.largest_clique(), {})
+
+                    cache = bgc.get_clique_cache(sparse=sparse, compress=compress)
+                    tmp.update_clique_cache(cache, write_to_disk=False)
+                    #test loading from memory
+                    for n, c in enumerate(cliques):
+                        self.assertEqual(set(c.values()), set(tmp.find_clique_embedding(n).values()))
+
+                    tmp.update_clique_cache(cache, write_to_disk=True)
+
+                    tmp = busclique.busgraph_cache(p4, seed=101)
+                    #test loading from disk
+                    for n, c in enumerate(cliques):
+                        self.assertEqual(set(c.values()), set(tmp.find_clique_embedding(n).values()))
+
+    def test_cache_merge(self):
+        p4 = self.p4_nd[0] 
+        bgc0 = busclique.busgraph_cache(p4, seed=200)
+        bgc1 = busclique.busgraph_cache(p4, seed=300)
+        bgc = busclique.busgraph_cache(p4, seed=400)
+        bgc.update_clique_cache(bgc0.get_clique_cache(), write_to_disk=False)
+        bgc.merge_clique_cache(bgc1, write_to_disk=False)
+        for n in range(1, len(bgc.largest_clique())):
+            emb = bgc.find_clique_embedding(n)
+            emb0 = bgc0.find_clique_embedding(n)
+            emb1 = bgc1.find_clique_embedding(n)
+            maxlen0 = max(map(len, emb0.values())) if emb0 else 999
+            maxlen1 = max(map(len, emb1.values())) if emb1 else 999
+            maxlen = max(map(len, emb.values()))
+            self.assertEqual(maxlen, min(maxlen0, maxlen1))
+
+        maxlen = max(map(len, bgc.largest_clique().values()))
+        for n in range(maxlen):
+            emb = bgc.largest_clique_by_chainlength(n)
+            emb0 = bgc0.largest_clique_by_chainlength(n)
+            emb1 = bgc1.largest_clique_by_chainlength(n)
+            self.assertEqual(len(emb), max(len(emb0), len(emb1)))
+
+    def test_mine_clique_embeddings_smoketest(self):
+        busclique.mine_clique_embeddings(
+            self.p4_nd[0],
+            num_seeds=1,
+            heuristic_bound=16,
+            heuristic_args=dict(tries=1, max_no_improvement=1, chainlength_patience=0),
+            heuristic_runs=1,
+        )
+
 def find_nondeterminism(family, size=4, tries=10):
     if family == 'pegasus':
         generator = dnx.pegasus_graph

--- a/tests/test_busclique.py
+++ b/tests/test_busclique.py
@@ -437,7 +437,7 @@ class TestBusclique(unittest.TestCase):
             self.p4_nd[0],
             num_seeds=1,
             heuristic_bound=8,
-            heuristic_args=dict(tries=1, max_no_improvement=1, chainlength_patience=0),
+            heuristic_args=dict(tries=1, max_no_improvement=1, chainlength_patience=0, verbose=2),
             heuristic_runs=1,
         )
 


### PR DESCRIPTION
Addresses #213, allows clique embedding caches to be exported, imported, and merged.