### PR TITLE
Add topology_identifier method to busgraph_cache

### DIFF
--- a/minorminer/busclique.pyx
+++ b/minorminer/busclique.pyx
@@ -1273,7 +1273,7 @@ def mine_clique_embeddings(
     for i in range(num_seeds):
         logger.info("polynomial embedder run %d of %d", i+1, num_seeds)
         seed = random.randint(0, 2**32-1)
-        bgc_i = busgraph_cache(g, seed=i)
+        bgc_i = busgraph_cache(g, seed=seed)
         bgc_i._graph.set_mask_bound(mask_bound)
         bgc.merge_clique_cache(bgc_i, write_to_disk=False, quality_function=quality_function)
         if regularize:

--- a/minorminer/busclique.pyx
+++ b/minorminer/busclique.pyx
@@ -28,7 +28,7 @@ from json import dumps, loads
 import networkx as nx
 import dwave_networkx as dnx
 from itertools import zip_longest
-
+from hashlib import sha256
 
 from cpython.mem cimport PyMem_Malloc, PyMem_Free
 from cpython.bytes cimport PyBytes_FromStringAndSize
@@ -181,6 +181,16 @@ class busgraph_cache:
         """Fetch/compute the clique cache, if it's not already in memory."""
         if self._bicliques is None:
             self._bicliques = self._fetch_cache('biclique', self._graph.bicliques)
+
+    def topology_identifier(self):
+        """Return a string identifying the busgraph basing this cache.
+
+        Note that we're using sha256 to generate this.  If a collision is detected,
+        the newsworthiness of that would be worth the hassle of dealing with the
+        fallout."""
+        s = sha256(self._graph.identifier)
+        s.update(__cache_version.to_bytes(sizeof(__cache_version), 'little'))
+        return s.hexdigest()
 
     @staticmethod
     def cache_rootdir(version=__cache_version):

--- a/minorminer/package_info.py
+++ b/minorminer/package_info.py
@@ -12,7 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-__version__ = "0.2.9"
+__version__ = "0.2.9.post0"
 __author__ = "Kelly Boothby"
 __authoremail__ = "boothby@dwavesys.com"
 __description__ = "heuristic algorithm to find graph minor embeddings"

--- a/tests/test_busclique.py
+++ b/tests/test_busclique.py
@@ -466,6 +466,35 @@ class TestBusclique(unittest.TestCase):
         p4.remove_edges_from(missing_edges)
         busclique._regularize_embedding(p4, emb)                  
 
+    def test_topology_identifier(self):
+        perfect_id = '38cad89632b234831d58675091f1bc581c96de65d4b2a0c06c0d94a7f97e21a7'
+        p16 = dnx.pegasus_graph(16)
+        bgc = busclique.busgraph_cache(p16)
+        self.assertEqual(
+            bgc.topology_identifier(),
+            perfect_id,
+            f'Topology identifier does not match expectation.  If busclique.__cache_version changed, this test needs to be updated.'
+        )
+
+        e = random.choice(list(p16.edges))
+        p16.remove_edge(*e)
+        bgc_e = busclique.busgraph_cache(p16)
+        self.assertNotEqual(
+            bgc_e.topology_identifier(),
+            perfect_id,
+            f'topology identifier did not change after removing edge {e}'
+        )
+
+        p16 = dnx.pegasus_graph(16)
+        n = random.choice(list(p16.nodes))
+        p16.remove_node(n)
+        bgc_n = busclique.busgraph_cache(p16)
+        self.assertNotEqual(
+            bgc_n.topology_identifier(),
+            perfect_id,
+            f'topology identifier did not change after removing node {n}'
+        )
+
 
 def find_nondeterminism(family, size=4, tries=10):
     if family == 'pegasus':


### PR DESCRIPTION
To support external logistics of embedding caches, we need a way of identifying a graph in a consistent manner.  We already have functionality for that on a single host, but it's a largeish binary blob.  For external use, we use the hexdigest of a sha256 of that binary blob.

Also contains a drive-by bugfix of #222