### PR TITLE
Extend networkx support beyond version 2.4

### DIFF
--- a/minorminer/layout/__init__.py
+++ b/minorminer/layout/__init__.py
@@ -151,10 +151,10 @@ def _parse_layout_parameter(S, T, layout, layout_kwargs):
     """Determine what combination of iterable, dict, and function the layout 
     parameter is.
     """
-    if nx.utils.iterable(layout):
-        try:
+    if isinstance(layout, (tuple, list)):
+        if len(layout) == 2:
             s_layout, t_layout = layout
-        except ValueError:
+        else:
             raise ValueError(
                 "layout is expected to be a function or a length-2 iterable")
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy==1.22.3;python_version>="3.8"
 numpy==1.21.6;python_version<"3.8"
 scipy==1.8.0;python_version>="3.8"
 scipy==1.7.3;python_version<"3.8"
-networkx==2.4
+networkx>=2.4
 dwave-networkx>=0.8.11
 fasteners==0.15
 homebase==1.0.1

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,15 @@ classifiers = [
 
 python_requires = '>=3.7'
 install_requires = [
-    "scipy", "networkx", "dwave-networkx>=0.8.10", "numpy", "fasteners", "homebase", "rectangle-packer>=2.0.1"
+    "numpy==1.22.3;python_version>=3.8",
+    "numpy==1.21.6;python_version<3.8",
+    "scipy==1.8.0;python_version>=3.8",
+    "scipy==1.7.3;python_version<3.8",
+    "networkx>=2.4",
+    "dwave-networkx>=0.8.11",
+    "fasteners==0.15",
+    "homebase==1.0.1",
+    "rectangle-packer>=2.0.1",
 ]
 
 setup(


### PR DESCRIPTION
I've tested locally with py3.8.6 and networkx 2.4, 2.8.6 and 3.1