### PR TITLE
Test dependency ranges in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,6 +272,35 @@ jobs:
             pip install -r test_requirements.txt
             pytest tests/
 
+  test-dependencies:
+    parameters:
+      dependency-versions:
+        type: string
+      python-version:
+        type: string
+
+    docker:
+      - image: python:<< parameters.python-version >>-slim
+
+    steps:
+      - checkout
+      - attach_workspace:
+          at: dist
+      - run:
+          name: install
+          command: |
+            python -m venv env
+            . env/bin/activate
+            pip install --upgrade << parameters.dependency-versions >>
+            pip install minorminer --no-index -f dist/ --no-deps --force-reinstall
+      - run:
+          name: run tests
+          command: |
+            . env/bin/activate
+            pip install --upgrade setuptools pip
+            pip install -r test_requirements.txt
+            pytest tests/
+
 workflows:
   test:
     jobs:
@@ -302,6 +331,20 @@ workflows:
       - test-sdist:
           requires:
             - build-sdist 
+      - test-dependencies:
+          requires:
+            - build-and-test-linux
+          matrix:
+            parameters:
+              python-version: *python-versions
+              dependency-versions: ["dwave-networkx==0.8.10 fasteners==0.15 homebase==1.0.1 networkx==2.4 oldest-supported-numpy rectangle-packer==2.0.1 scipy==1.7.3",  # oldest supported
+                                    "dwave-networkx fasteners homebase networkx numpy rectangle-packer scipy", # latest
+                                    ]
+            exclude:
+              # SciPy 1.7.3 doesn't support Python 3.11
+              - python-version: 3.11.0
+                dependency-versions: "dwave-networkx==0.8.10 fasteners==0.15 homebase==1.0.1 networkx==2.4 oldest-supported-numpy rectangle-packer==2.0.1 scipy==1.7.3"
+
   deploy:
     jobs:
       - build-and-test-linux: &deploy-build

--- a/minorminer/layout/__init__.py
+++ b/minorminer/layout/__init__.py
@@ -151,10 +151,10 @@ def _parse_layout_parameter(S, T, layout, layout_kwargs):
     """Determine what combination of iterable, dict, and function the layout 
     parameter is.
     """
-    if nx.utils.iterable(layout):
-        try:
+    if isinstance(layout, (tuple, list)):
+        if len(layout) == 2:
             s_layout, t_layout = layout
-        except ValueError:
+        else:
             raise ValueError(
                 "layout is expected to be a function or a length-2 iterable")
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ dwave-networkx>=0.8.11
 fasteners==0.15
 homebase==1.0.1
 Cython==0.29.24
-rectangle-packer>=2.0.1
+rectangle-packer==2.0.1

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,13 @@ classifiers = [
 
 python_requires = '>=3.7'
 install_requires = [
-    "scipy", "networkx", "dwave-networkx>=0.8.10", "numpy", "fasteners", "homebase", "rectangle-packer>=2.0.1"
+    "dwave-networkx>=0.8.10",
+    "fasteners>=0.15",
+    "homebase>=1.0.1",
+    "networkx>=2.4",
+    "numpy>=1.21.6",
+    "rectangle-packer>=2.0.1",
+    "scipy>=1.7.3",
 ]
 
 setup(


### PR DESCRIPTION
We only test the min and latest version of the dependency ranges. We could be more fine grained, but until we run into a specific issue I think this suffices.

Closes https://github.com/dwavesystems/minorminer/pull/232 as redundant.