### PR TITLE
Rectangle-packer module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ wheels/
 minorminer/_minorminer.cpp
 minorminer/busclique.cpp
 minorminer/subgraph.cpp
+minorminer/_extern/rpack/_core.c
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ global-include *.hpp
 recursive-include external/glasgow-subgraph-solver *.hh LICENSE
 recursive-include external/portable-snippets builtin.h COPYING.md
 recursive-include external/boost BOOST_LICENSE
+recursive-include minorminer/_extern LICENSE.md

--- a/minorminer/_extern/__init__.pyx
+++ b/minorminer/_extern/__init__.pyx
@@ -1,0 +1,2 @@
+# required for Cython to find and compile files in included packages
+"""Code from external packages required by minorminer."""

--- a/minorminer/_extern/rpack/LICENSE.md
+++ b/minorminer/_extern/rpack/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Daniel Andersson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/minorminer/_extern/rpack/__init__.py
+++ b/minorminer/_extern/rpack/__init__.py
@@ -169,7 +169,7 @@ __version__ = '2.0.2'
 from typing import Iterable, Tuple, List
 
 # Extension modules
-from rpack._core import (
+from minorminer._extern.rpack._core import (
     pack as _pack,
     PackingImpossibleError,
     bbox_size,

--- a/minorminer/_extern/rpack/__init__.py
+++ b/minorminer/_extern/rpack/__init__.py
@@ -1,0 +1,244 @@
+"""Pack a set of rectangles into a bounding box with minimum area
+
+===========================
+Welcome to rectangle-packer
+===========================
+
+|PyPI-Versions| |PyPI-Wheel| |Build-Status| |Read-the-Docs| |GitHub-License|
+
+|PyPI-Downloads|
+
+**Primary use:** Given a set of rectangles with fixed orientations,
+find a bounding box of minimum area that contains them all with no
+overlap.
+
+This project is inspired by Matt Perdeck's blog post `Fast Optimizing
+Rectangle Packing Algorithm for Building CSS Sprites`_.
+
+* The latest documentation is available on `Read the Docs`_.
+* The source code is available on `GitHub`_.
+
+
+Installation
+============
+
+Install latest version from `PyPI`_:
+
+.. code:: sh
+
+    $ python3 -m pip install rectangle-packer
+
+Or `clone the repository`_ and install with:
+
+.. code:: sh
+
+    $ python3 setup.py install
+
+
+Basic usage
+===========
+
+.. code:: python
+
+    # Import the module
+    >>> import rpack
+
+    # Create a bunch of rectangles (width, height)
+    >>> sizes = [(58, 206), (231, 176), (35, 113), (46, 109)]
+
+    # Pack
+    >>> positions = rpack.pack(sizes)
+
+    # The result will be a list of (x, y) positions:
+    >>> positions
+    [(0, 0), (58, 0), (289, 0), (289, 113)]
+
+The output positions are the lower left corner coordinates of each
+rectangle in the input.
+
+These positions will yield a packing with no overlaps and enclosing
+area as small as possible (best effort).
+
+.. note::
+
+    * You must use **positive integers** as rectangle width and height.
+
+    * The module name is **rpack** which is an abbreviation of the package
+      name at PyPI (rectangle-packer).
+
+    * The computational time required by :py:func:`rpack.pack` increases by
+      the number *and* size of input rectangles.  If this becomes a problem,
+      you might need to implement your own `divide-and-conquer algorithm`_.
+
+
+Examples
+========
+
+**Example A:**
+
+.. only:: latex
+
+  .. image:: https://penlect.com/rpack/2.0.1/img/packing_best_10.pdf
+     :alt: pack10
+     :align: center
+
+.. only:: html
+
+  .. figure:: https://penlect.com/rpack/2.0.1/img/packing_best_10.svg
+     :alt: pack10
+     :align: center
+
+**Example B:**
+
+.. only:: latex
+
+  .. image:: https://penlect.com/rpack/2.0.1/img/packing_phi.pdf
+     :alt: packphi
+     :align: center
+
+.. only:: html
+
+  .. figure:: https://penlect.com/rpack/2.0.1/img/packing_phi.svg
+     :alt: packphi
+     :align: center
+
+
+**Example C:** Sometimes the input rectangles simply cannot be packed in
+a good way. Here is an example of low packing density:
+
+.. only:: latex
+
+  .. image:: https://penlect.com/rpack/2.0.1/img/packing_worst_10.pdf
+     :alt: pack10bad
+     :align: center
+
+.. only:: html
+
+  .. figure:: https://penlect.com/rpack/2.0.1/img/packing_worst_10.svg
+     :alt: pack10bad
+     :align: center
+
+
+**Example D:** The image below is contributed by Paul Brodersen, and
+illustrates a solution to a problem discussed at stackoverflow_.
+
+.. image:: https://i.stack.imgur.com/kLat8.png
+    :alt: PaulBrodersenExampleImage
+    :align: center
+    :width: 450px
+
+
+.. _Read the Docs: https://rectangle-packer.readthedocs.io/en/latest/
+.. _GitHub: https://github.com/Penlect/rectangle-packer
+.. _`Fast Optimizing Rectangle Packing Algorithm for Building CSS Sprites`: http://www.codeproject.com/Articles/210979/Fast-optimizing-rectangle-packing-algorithm-for-bu
+.. _`clone the repository`: https://github.com/Penlect/rectangle-packer
+.. _stackoverflow: https://stackoverflow.com/a/53156709/2912349
+.. _PyPI: https://pypi.org/project/rectangle-packer/
+..  _`divide-and-conquer algorithm`: https://en.wikipedia.org/wiki/Divide-and-conquer_algorithm
+
+.. |PyPI-Versions| image:: https://img.shields.io/pypi/pyversions/rectangle-packer.svg
+   :target: https://pypi.org/project/rectangle-packer
+
+.. |PyPI-Wheel| image:: https://img.shields.io/pypi/wheel/rectangle-packer.svg
+   :target: https://pypi.org/project/rectangle-packer
+
+.. |Build-Status| image:: https://travis-ci.com/Penlect/rectangle-packer.svg?branch=master
+   :target: https://travis-ci.com/Penlect/rectangle-packer
+
+.. |Read-the-Docs| image:: https://img.shields.io/readthedocs/rectangle-packer.svg
+   :target: https://rectangle-packer.readthedocs.io/en/latest
+
+.. |GitHub-License| image:: https://img.shields.io/github/license/Penlect/rectangle-packer.svg
+   :target: https://raw.githubusercontent.com/Penlect/rectangle-packer/travis/LICENSE.md
+
+.. |PyPI-Downloads| image:: https://img.shields.io/pypi/dm/rectangle-packer.svg
+   :target: https://pypi.org/project/rectangle-packer
+"""
+
+# Module metadata
+__author__ = 'Daniel Andersson'
+__maintainer__ = __author__
+__email__ = 'daniel.4ndersson@gmail.com'
+__contact__ = __email__
+__copyright__ = 'Copyright (c) 2017 Daniel Andersson'
+__license__ = 'MIT'
+__url__ = 'https://github.com/Penlect/rectangle-packer'
+__version__ = '2.0.2'
+
+# Built-in
+from typing import Iterable, Tuple, List
+
+# Extension modules
+from rpack._core import (
+    pack as _pack,
+    PackingImpossibleError,
+    bbox_size,
+    packing_density,
+    overlapping
+)
+
+enclosing_size = bbox_size
+
+
+def pack(sizes: Iterable[Tuple[int, int]],
+         max_width=None, max_height=None) -> List[Tuple[int, int]]:
+    """Pack rectangles into a bounding box with minimal area.
+
+    The result is returned as a list of coordinates "(x, y)", which
+    specifices the location of each corresponding input rectangle's
+    lower left corner.
+
+    The helper function :py:func:`bbox_size` can be used to compute
+    the width and height of the resulting bounding box.  And
+    :py:func:`packing_density` can be used to evaluate the packing
+    quality.
+
+    The algorithm will sort the input in different ways internally so
+    there is no need to sort ``sizes`` in advance.
+
+    The GIL is released when C-intensive code is running.  Execution
+    time increases by the number *and* size of input rectangles.  If
+    this becomes a problem, you might need to implement your own
+    `divide-and-conquer algorithm`_.
+
+    **Example**::
+
+        # Import the module
+        >>> import rpack
+
+        # Create a bunch of rectangles (width, height)
+        >>> sizes = [(58, 206), (231, 176), (35, 113), (46, 109)]
+
+        # Pack
+        >>> positions = rpack.pack(sizes)
+
+        # The result will be a list of (x, y) positions:
+        >>> positions
+        [(0, 0), (58, 0), (289, 0), (289, 113)]
+
+    ..  _`divide-and-conquer algorithm`: https://en.wikipedia.org/wiki/Divide-and-conquer_algorithm
+
+    :param sizes: "(width, height)" of the rectangles to pack.  *Note:
+        integer values only!*
+    :type sizes: Iterable[Tuple[int, int]]
+
+    :param max_width: Force the enclosing rectangle to not exceed a
+        maximum width.  If not possible,
+        :py:exc:`rpack.PackingImpossibleError` will be raised.
+    :type max_width: Union[None, int]
+
+    :param max_height: Force the enclosing rectangle to not exceed a
+        maximum height.  If not possible,
+        :py:exc:`rpack.PackingImpossibleError` will be raised.
+    :type max_height: Union[None, int]
+
+    :return: List of positions (x, y) of the input rectangles.
+    :rtype: List[Tuple[int, int]]
+    """
+    if max_width is not None and not isinstance(max_width, int):
+        raise TypeError("max_width must be an integer")
+    if max_height is not None and not isinstance(max_height, int):
+        raise TypeError("max_height must be an integer")
+    if not isinstance(sizes, list):
+        sizes = list(sizes)
+    return _pack(sizes, max_width or -1, max_height or -1)

--- a/minorminer/_extern/rpack/_core.pxd
+++ b/minorminer/_extern/rpack/_core.pxd
@@ -1,0 +1,42 @@
+
+
+cdef extern from "rpackcore.h":
+
+    ctypedef struct Rectangle:
+        long width
+        long height
+        long x
+        long y
+        size_t index
+        long area
+        bint wide
+        bint rotated
+
+    ctypedef struct Cell
+
+    cdef long start_pos(Cell *cell) nogil
+
+    ctypedef struct Region:
+        Cell *row_cell_start
+        Cell *col_cell_start
+        Cell *col_cell
+
+    ctypedef struct BBoxRestrictions:
+        long min_width
+        long max_width
+        long min_height
+        long max_height
+        long max_area
+
+    ctypedef struct CGrid "Grid":
+        size_t size
+        long width
+        long height
+
+    cdef:
+        CGrid *grid_alloc(size_t size, long width, long height) nogil
+        void grid_free(CGrid *grid) nogil
+        void grid_clear(CGrid *self) nogil
+        int grid_find_region(CGrid *grid, Rectangle *rectangle, Region *reg) nogil
+        void grid_split(CGrid *self, Region *reg) nogil
+        long grid_search_bbox(CGrid *grid, Rectangle *sizes, BBoxRestrictions *bbr) nogil

--- a/minorminer/_extern/rpack/_core.pyx
+++ b/minorminer/_extern/rpack/_core.pyx
@@ -1,0 +1,527 @@
+"""Core functions"""
+
+# Built-in
+import collections
+import math
+from typing import Tuple
+
+# Cython
+import cython
+from libc.stdlib cimport malloc, free, qsort
+from libc.limits cimport LONG_MAX
+from cpython.mem cimport PyMem_Malloc, PyMem_Free
+
+
+DEF NO_POSITION = -1
+DEF CASE_0 = 0
+DEF CASE_1 = 1
+DEF CASE_2 = 2
+DEF CASE_3 = 3
+DEF CASE_4 = 4
+
+
+class PackingImpossibleError(Exception):
+    """Packing rectangles is impossible with imposed restrictions.
+
+    This can happen, for example, if `max_width` is strictly less than
+    the widest rectangle given to :py:func:`rpack.pack`.
+
+    If possible, a partial result will be given in the second
+    argument, with the positions of packed rectangles up till the
+    point of failure.
+    """
+
+# The following four functions are used as compare-functions for
+# sorting `Rectangle` structs by index, width, height and area.
+
+cdef int rectangle_index_cmp(const void *a, const void *b) noexcept nogil:
+    cdef int index_a, index_b
+    index_a = (<Rectangle*>a)[0].index
+    index_b = (<Rectangle*>b)[0].index
+    if index_a < index_b:
+        return -1
+    elif index_a == index_b:
+        return 0
+    else:
+        return 1
+
+
+cdef int rectangle_width_cmp(const void *a, const void *b) noexcept nogil:
+    cdef int width_a, width_b
+    width_a = (<Rectangle*>a)[0].width
+    width_b = (<Rectangle*>b)[0].width
+    if width_a < width_b:
+        return 1
+    elif width_a == width_b:
+        return rectangle_area_cmp(a, b)
+    else:
+        return -1
+
+
+cdef int rectangle_height_cmp(const void *a, const void *b) noexcept nogil:
+    cdef int height_a, height_b
+    height_a = (<Rectangle*>a)[0].height
+    height_b = (<Rectangle*>b)[0].height
+    if height_a < height_b:
+        return 1
+    elif height_a == height_b:
+        return rectangle_area_cmp(a, b)
+    else:
+        return -1
+
+
+cdef int rectangle_area_cmp(const void *a, const void *b) noexcept nogil:
+    cdef int area_a, area_b
+    area_a = (<Rectangle*>a)[0].area
+    area_b = (<Rectangle*>b)[0].area
+    if area_a < area_b:
+        return 1
+    elif area_a == area_b:
+        return 0
+    else:
+        return -1
+
+
+cdef class RectangleSet:
+    """Container for a set of rectangles to be packed."""
+
+    cdef:
+        Rectangle *rectangles
+        Py_ssize_t length
+        long sum_width
+        long sum_height
+
+        long min_width
+        long min_height
+
+        long max_width
+        long max_height
+
+        long area
+
+
+    def __cinit__(self, sizes):
+        cdef:
+            size_t i
+            long w, h
+
+        if len(sizes) == 0:
+            raise ValueError('Empty sizes')
+        self.length = len(sizes)
+        self.min_height = LONG_MAX
+        self.min_width = LONG_MAX
+
+        # Prepare input
+        self.rectangles = NULL
+        self.rectangles = <Rectangle *> PyMem_Malloc(<size_t>self.length * sizeof(Rectangle))
+        if not self.rectangles:
+            raise MemoryError('Rectangles')
+        i = 0
+        for width, height in sizes:
+            if not isinstance(width, int):
+                raise TypeError("Rectangle width must be an integer")
+            if not isinstance(height, int):
+                raise TypeError("Rectangle height must be an integer")
+            w = <long>width
+            h = <long>height
+            if w <= 0:
+                raise ValueError("Rectangle width must be positive integer")
+            elif h <= 0:
+                raise ValueError("Rectangle height must be positive integer")
+
+            self.sum_width += w
+            self.sum_height += h
+
+            if self.max_width < w:
+                self.max_width = w
+            if self.max_height < h:
+                self.max_height = h
+
+            if w < self.min_width:
+                self.min_width = w
+            if h < self.min_height:
+                self.min_height = h
+
+            self.area += w*h
+
+            self.rectangles[i].width = w
+            self.rectangles[i].height = h
+            self.rectangles[i].x = NO_POSITION
+            self.rectangles[i].y = NO_POSITION
+            self.rectangles[i].index = i
+            self.rectangles[i].area = w*h
+            self.rectangles[i].wide = (w >= h)
+            self.rectangles[i].rotated = False
+            i += 1
+
+    def __dealloc__(self):
+        # Note: this is called if Exceptions are raised in __cinit__
+        if self.rectangles != NULL:
+            PyMem_Free(self.rectangles)
+
+    def __iter__(self):
+        cdef size_t i
+        for i in range(self.length):
+            yield self.rectangles[i]
+
+    cdef list positions(self):
+        cdef size_t i = 0, end_i = 0
+        for i in range(self.length):
+            if self.rectangles[i].x == NO_POSITION or \
+                   self.rectangles[i].y == NO_POSITION:
+                break
+            end_i = i + 1
+        self.sort_by_index(end_i)
+        output = [(self.rectangles[i].x, self.rectangles[i].y)
+                  for i in range(end_i)]
+        if end_i != self.length:
+            raise PackingImpossibleError(f"Partial result", output)
+        return output
+
+    cdef bbox_size(self):
+        cdef:
+            long max_width = 0, max_height = 0
+            Rectangle *r
+            size_t i
+        for i in range(self.length):
+            r = &self.rectangles[i]
+            if r.x == NO_POSITION or r.y == NO_POSITION:
+                break
+            if r.width + r.x > max_width:
+                max_width = r.width + r.x
+            if r.height + r.y > max_height:
+                max_height = r.height + r.y
+        return max_width, max_height
+
+    cdef void rotate_all(self) nogil:
+        cdef size_t i
+        cdef Rectangle *r
+        for i in range(self.length):
+            r = &self.rectangles[i]
+            r.width, r.height = r.height, r.width
+            r.rotated = not r.rotated
+            r.wide = r.width >= r.height
+        self.sum_width, self.sum_height = self.sum_height, self.sum_width
+        self.min_width, self.min_height = self.min_height, self.min_width
+        self.max_width, self.max_height = self.max_height, self.max_width
+
+    cdef void sort_by_index(self, size_t length) nogil:
+        qsort(<void*>(self.rectangles), length, sizeof(Rectangle), rectangle_index_cmp)
+
+    cdef void sort_by_width(self) nogil:
+        qsort(<void*>(self.rectangles), self.length, sizeof(Rectangle), rectangle_width_cmp)
+
+    cdef void sort_by_height(self) nogil:
+        qsort(<void*>(self.rectangles), self.length, sizeof(Rectangle), rectangle_height_cmp)
+
+    cdef void sort_by_area(self) nogil:
+        qsort(<void*>(self.rectangles), self.length, sizeof(Rectangle), rectangle_area_cmp)
+
+    cdef void translate(self, long x, long y) nogil:
+        cdef size_t i
+        cdef Rectangle *r
+        for i in range(self.length):
+            r = &self.rectangles[i]
+            r.x += x
+            r.y += y
+
+    cdef void transpose(self) nogil:
+        cdef size_t i
+        cdef Rectangle *r
+        for i in range(self.length):
+            r = &self.rectangles[i]
+            r.x, r.y = r.y, r.x
+
+
+cdef class Grid:
+
+    cdef:
+        Py_ssize_t length
+        CGrid *cgrid
+
+    def __cinit__(self, size_t size, long width=0, long height=0):
+        self.cgrid = grid_alloc(size, width, height)
+        if not self.cgrid:
+            raise MemoryError('Grid')
+
+    def __dealloc__(self):
+        if self.cgrid != NULL:
+            grid_free(self.cgrid)
+
+    cdef (long, long) search_bbox(
+            self, RectangleSet rset, BBoxRestrictions *bbr):
+        cdef long status
+        if self.cgrid.size + 1 < rset.length:
+            raise PackingImpossibleError(
+                "Too many rectangles for allocated grid size.", [])
+        assert bbr.min_width == rset.max_width
+        assert bbr.min_height == rset.max_height
+        with nogil:
+            status = grid_search_bbox(self.cgrid, rset.rectangles, bbr)
+        if status >= 0:
+            return self.cgrid.width, self.cgrid.height
+        return self.cgrid.width, -self.cgrid.height
+
+    cdef int pack(self, RectangleSet rset, long width, long height) except -1:
+        cdef size_t i = 0
+        cdef Region reg
+        if self.cgrid.size + 1 < rset.length:
+            raise PackingImpossibleError(
+                "Too many rectangles for allocated grid size.", [])
+        with nogil:
+            self.cgrid.width = width
+            self.cgrid.height = height
+            grid_clear(self.cgrid)
+            for i in range(rset.length):
+                r = &rset.rectangles[i]
+                grid_find_region(self.cgrid, r, &reg)
+                if reg.col_cell == NULL:
+                    r.x = NO_POSITION
+                    r.y = NO_POSITION
+                    return 1
+                r.x = start_pos(reg.col_cell_start)
+                r.y = start_pos(reg.row_cell_start)
+                grid_split(self.cgrid, &reg)
+        return 0
+
+
+def pack(sizes, long max_width, long max_height):
+    """Pack rectangles by testing four different strategies.
+
+    Strategies:
+
+        - Sort by height.
+
+        - Sort by width.
+
+        - Rotate and sort by height.
+
+        - Rotate and sort by width.
+
+    The result of the best one will be returned.
+
+    If ``max_width`` is negative, it will be ignored.  Same for
+    ``max_height``.
+
+    If ``max_width`` or ``max_height`` is too restrictive, a
+    ``PackingImpossibleError`` exception might be issued.
+    """
+    cdef:
+        long area = LONG_MAX
+        long w = 0, h = 0, best_w = 0, best_h = 0
+        int case = CASE_0
+        BBoxRestrictions bbr
+
+    # Abort early
+    n = len(sizes)
+    if n == 0:
+        return list()
+
+    cdef RectangleSet rset = RectangleSet(sizes)
+
+    if max_width < 0:
+        max_width = rset.sum_width
+    elif max_width == 0:
+        raise PackingImpossibleError("max_width zero", list())
+    elif max_width < rset.max_width:
+        raise PackingImpossibleError("max_width less than widest rectangle", list())
+
+    if max_height < 0:
+        max_height = rset.sum_height
+    elif max_height == 0:
+        raise PackingImpossibleError("max_height zero", list())
+    elif max_height < rset.max_height:
+        raise PackingImpossibleError("max_height less than highest rectangle", list())
+
+    grid = Grid(rset.length + 1, 0, 0)
+    bbr = BBoxRestrictions(
+        min_width=rset.max_width,
+        max_width=max_width,
+        min_height=rset.max_height,
+        max_height=max_height,
+        max_area=area
+    )
+    best_w = max_width
+    best_h = max_height
+
+    rset.sort_by_height()
+    w, h = grid.search_bbox(rset, &bbr)
+    area = w*h
+    if 0 < area < bbr.max_area:
+        bbr.max_area = area
+        best_w = w
+        best_h = h
+        case = CASE_1
+
+    rset.sort_by_width()
+    w, h = grid.search_bbox(rset, &bbr)
+    area = w*h
+    if 0 < area < bbr.max_area:
+        bbr.max_area = area
+        best_w = w
+        best_h = h
+        case = CASE_2
+
+    # Rotated
+
+    rset.rotate_all()
+    bbr.min_width = rset.max_width
+    bbr.max_width = max_height
+    bbr.min_height = rset.max_height
+    bbr.max_height = max_width
+
+    w, h = grid.search_bbox(rset, &bbr)
+    area = w*h
+    if 0 < area < bbr.max_area:
+        bbr.max_area = area
+        best_w = w
+        best_h = h
+        case = CASE_3
+
+    rset.sort_by_width()
+    w, h = grid.search_bbox(rset, &bbr)
+    area = w*h
+    if 0 < area < bbr.max_area:
+        bbr.max_area = area
+        best_w = w
+        best_h = h
+        case = CASE_4
+
+    # Restore rset to best case
+    if case == CASE_0:
+        best_w = bbr.max_width
+        best_h = bbr.max_height
+    elif case == CASE_1:
+        rset.rotate_all()
+    elif case == CASE_2:
+        rset.rotate_all()
+        rset.sort_by_width()
+    elif case == CASE_3:
+        rset.sort_by_height()
+    elif case == CASE_4:
+        pass
+
+    grid.pack(rset, best_w, best_h)
+
+    # Restore rectangles if rotated
+    if case == CASE_0 or case == CASE_3 or case == CASE_4:
+        rset.transpose()
+
+    return rset.positions()
+
+
+def bbox_size(sizes, positions) -> Tuple[int, int]:
+    """Return bounding box size (width, height) of packed rectangles.
+
+    Useful for evaluating the result of :py:func:`rpack.pack`.
+
+    Example::
+
+        >>> import rpack
+
+        >>> sizes = [(58, 206), (231, 176), (35, 113), (46, 109)]
+        >>> positions = rpack.pack(sizes)
+
+        >>> bbox_size(sizes, positions)
+        (335, 222)
+
+    :param sizes: List of rectangle sizes (width, height).
+    :type sizes: List[Tuple[int, int]]
+
+    :param positions: List of rectangle positions (x, y).
+    :type positions: List[Tuple[int, int]]
+
+    :return: Size (width, height) of bounding box covering rectangles
+             having `sizes` and `positions`.
+    :rtype: Tuple[int, int]
+    """
+    cdef long max_width = 0, max_height = 0, w, h, x, y
+    for i in range(len(sizes)):
+        w, h = sizes[i]
+        x, y = positions[i]
+        if w + x > max_width:
+            max_width = w + x
+        if h + y > max_height:
+            max_height = h + y
+    return max_width, max_height
+
+
+def packing_density(sizes, positions) -> float:
+    """Return packing density of packed rectangles.
+
+    Useful for evaluating the result of :py:func:`rpack.pack`.
+
+    Example::
+
+        >>> import rpack
+
+        >>> sizes = [(58, 206), (231, 176), (35, 113), (46, 109)]
+        >>> positions = rpack.pack(sizes)
+
+        >>> packing_density(sizes, positions)
+        0.8279279279279279
+
+    :param sizes: List of rectangle sizes (width, height).
+    :type sizes: List[Tuple[int, int]]
+
+    :param positions: List of rectangle positions (x, y).
+    :type positions: List[Tuple[int, int]]
+
+    :return: Packing density as a fraction in the interval [0, 1],
+             where 1 means that the bounding box area equals the sum
+             of the areas of the rectangles packed, i.e. perfect
+             packing.
+    :rtype: float
+    """
+    w, h = bbox_size(sizes, positions)
+    area_bounding_box = w*h
+    area_rectangles = sum(w*h for w, h in sizes)
+    return area_rectangles/area_bounding_box
+
+
+def overlapping(sizes, positions):
+    """Return indices of overlapping rectangles, else ``None``.
+
+    Mainly used for test cases.
+
+    Example::
+
+        >>> sizes = [(10, 10), (10, 10)]
+
+        >>> positions = [(0, 0), (10, 10)]
+        >>> overlapping(sizes, positions) is None
+        True
+
+        >>> positions = [(0, 0), (5, 5)]
+        >>> overlapping(sizes, positions)
+        (0, 1)
+
+    :param sizes: List of rectangle sizes (width, height).
+    :type sizes: List[Tuple[int, int]]
+
+    :param positions: List of rectangle positions (x, y).
+    :type positions: List[Tuple[int, int]]
+
+    :return: Return indices (i, j) if i-th and j-th rectangle overlap
+             (first case found).  Return ``None`` if no rectangles
+             overlap.
+    :rtype: Union[None, Tuple[int, int]]
+    """
+    cdef:
+        long w1, h1, x1, y1
+        long w2, h2, x2, y2
+        bint disjoint_in_x, disjoint_in_y
+        Py_ssize_t n = len(sizes)
+    for i in range(n):
+        w1, h1 = sizes[i]
+        x1, y1 = positions[i]
+        for j in range(n):
+            if j == i:
+                continue
+            w2, h2 = sizes[j]
+            x2, y2 = positions[j]
+            disjoint_in_x = (x1 + w1 <= x2 or x2 + w2 <= x1)
+            disjoint_in_y = (y1 + h1 <= y2 or y2 + h2 <= y1)
+            if not (disjoint_in_x or disjoint_in_y):
+                return (i, j)
+    return None

--- a/minorminer/_extern/rpack/include/rpackcore.h
+++ b/minorminer/_extern/rpack/include/rpackcore.h
@@ -1,0 +1,85 @@
+#ifndef CORE_H
+#define CORE_H
+
+#include <stdlib.h>
+
+// Cell
+struct cell {
+    long end_pos;
+    size_t jump_index;
+  
+    struct cell *prev;
+    struct cell *next;
+};
+typedef struct cell Cell;
+
+long start_pos(Cell *cell);
+
+// CellLink
+struct cell_link {
+    size_t size;
+    long end_pos;
+    size_t jump_index;
+    Cell *cells;
+    Cell *head;
+};
+typedef struct cell_link CellLink;
+
+// JumpMatrix
+typedef Cell ***JumpMatrix;
+
+// Region
+struct region {
+    Cell *row_cell_start;
+    Cell *row_cell;
+    long row_end_pos;
+    Cell *col_cell_start;
+    Cell *col_cell;
+    long col_end_pos;
+};
+typedef struct region Region;
+
+// Rectangle
+struct rectangle {
+    long width;
+    long height;
+    long x;
+    long y;
+    size_t index;
+    long area;
+    int wide;
+    int rotated;
+};
+typedef struct rectangle Rectangle;
+
+// BBoxRestrictions
+struct bbox_restrictions {
+    long min_width;
+    long max_width;
+    long min_height;
+    long max_height;
+    long max_area;
+};
+typedef struct bbox_restrictions BBoxRestrictions;
+
+// Grid
+struct grid {
+    size_t size;
+    long width;
+    long height;
+
+    CellLink *cols;
+    CellLink *rows;
+
+    JumpMatrix jump_matrix;
+};
+typedef struct grid Grid;
+
+Grid *grid_alloc(size_t size, long width, long height);
+void grid_free(Grid *grid);
+void grid_clear(Grid *self);
+int grid_find_region(Grid *grid, Rectangle *rectangle, Region *reg);
+void grid_split(Grid *self, Region *reg);
+long grid_search_bbox(Grid *grid, Rectangle *sizes, BBoxRestrictions *bbr);
+
+#endif

--- a/minorminer/_extern/rpack/src/rpackcore.c
+++ b/minorminer/_extern/rpack/src/rpackcore.c
@@ -1,0 +1,696 @@
+/* Core functions and data structures
+
+This file was formmatted with:
+
+$ indent -kr --no-tabs rpackcore.c
+
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <limits.h>
+
+#include "rpackcore.h"
+
+/* Cell
+   ====
+*/
+
+Cell _cell;
+Cell *const COL_FULL = &_cell;
+
+/* start_pos computes the starting position of a Cell by returning the
+   end position of the previous cell. */
+long start_pos(Cell * self)
+{
+    if (self == NULL) {
+        return 0;
+    } else if (self->prev == NULL) {
+        return 0;
+    } else {
+        return self->prev->end_pos;
+    }
+}
+
+/* CellLink
+   ========
+
+   The CellLink is used to handle the Grid's rows and columns. The
+   CellLink is a doubly linked list and each cell corresponds to a row
+   or column in the grid. Each cell has an end position which all
+   together define the row and column widths. Each cell has a
+   `jump_index`. These indecies are used when checking if a region,
+   defined by a row-cell and column-cell, is occupied or not.
+
+*/
+
+/* clear_cell_link restores the CellLink to the "starting state".
+   I.e. the CellLink will only have one cell which has the full
+   size. */
+static void clear_cell_link(CellLink * self)
+{
+    self->jump_index = 0;
+    self->head = &self->cells[0];
+    self->head->prev = NULL;
+    self->head->next = NULL;
+    self->head->end_pos = self->end_pos;
+    self->head->jump_index = self->jump_index;
+    self->jump_index++;
+    return;
+}
+
+/* free_cell_link frees the memory allocated by CellLink */
+static void free_cell_link(CellLink * cell_link)
+{
+    if (cell_link == NULL) {
+        return;
+    }
+    if (cell_link->cells != NULL) {
+        free(cell_link->cells);
+    }
+    free(cell_link);
+    return;
+}
+
+/* alloc_cell_link allocates memory for a new CellLink. `size` refers
+   to the maximum number of Cells the CellLink will contain. They are
+   all allocated at this step, but only added to the linked-list when
+   `cut` is called. */
+static CellLink *alloc_cell_link(size_t size, long end_pos)
+{
+    CellLink *cl = NULL;
+    Cell *cells = NULL;
+    if ((cl = malloc(sizeof(*cl))) == NULL) {
+        return NULL;
+    }
+    if ((cells = calloc(size, sizeof(*cells))) == NULL) {
+        free(cl);
+        return NULL;
+    }
+    if (size == 0) {
+        size = 1;
+    }
+    if (end_pos == 0) {
+        end_pos = 1;
+    }
+    cl->size = size;
+    cl->end_pos = end_pos;
+    cl->cells = cells;
+    clear_cell_link(cl);
+    return cl;
+}
+
+/* cut will 'split' an existing Cell and add another cell from the
+   preallocated list of Cells after it. The end positions will be
+   adjusted accordingly. */
+static void
+cut(CellLink * self, Cell * victim, long end_pos, size_t *src_i,
+    size_t *dest_i)
+{
+    Cell *new_cell = NULL;
+    new_cell = &self->cells[self->jump_index];
+    new_cell->end_pos = victim->end_pos;
+    new_cell->jump_index = *dest_i = self->jump_index;
+    self->jump_index++;         /* May overflow size if called to many times */
+
+    new_cell->prev = victim;
+    new_cell->next = victim->next;
+    victim->next = new_cell;
+    victim->end_pos = end_pos;
+    if (new_cell->next != NULL) {
+        new_cell->next->prev = new_cell;
+    }
+
+    *src_i = victim->jump_index;
+    return;
+}
+
+// =================================
+
+/* JumpMatrix
+   ==========
+
+   The JumpMatrix works like a look-up table to check if a region
+   defined by a row-cell and column-cell is free or not. If an element
+   is NULL that region is free, else occupied.
+*/
+
+/* alloc_jump_matrix allocates memory for a new JumpMatrix */
+static JumpMatrix alloc_jump_matrix(size_t size)
+{
+    size_t i, len = 0;
+    Cell **ptr, ***arr;
+
+    if (size == 0) {
+        size = 1;
+    }
+
+    len = sizeof(Cell **) * size + sizeof(Cell *) * size * size;
+    if ((arr = (Cell ***) malloc(len)) == NULL) {
+        return NULL;
+    }
+
+    /* Ptr is now pointing to the first element in of 2D array  */
+    ptr = (Cell **) (arr + size);
+
+    /* For loop to point rows pointer to appropriate location in 2D array  */
+    for (i = 0; i < size; i++) {
+        arr[i] = (ptr + size * i);
+    }
+    arr[0][0] = NULL;
+    return arr;
+}
+
+/* copy_row copies a range of elements decided by `jump_index_col`
+   from src-row to dest-row. */
+static void
+copy_row(JumpMatrix self, size_t src_i, size_t dest_i,
+         size_t jump_index_col)
+{
+    size_t index = 0;
+    for (index = 0; index < jump_index_col; index++) {
+        self[dest_i][index] = self[src_i][index];
+    }
+}
+
+/* copy_col copies a range of elements decided by `jump_index_row`
+   from src-col to dest-col. */
+static void
+copy_col(JumpMatrix self, size_t src_i, size_t dest_i,
+         size_t jump_index_row)
+{
+    size_t index = 0;
+    for (index = 0; index < jump_index_row; index++) {
+        self[index][dest_i] = self[index][src_i];
+    }
+}
+
+/* Grid
+   ====
+
+   The Grid contains two CellLinks - one for rows and one for
+   columns. It also contains a JumpMatrix to keep track of which
+   regions are free or not.
+*/
+
+/* grid_alloc allocates memory for a new Grid */
+Grid *grid_alloc(size_t size, long width, long height)
+{
+    Grid *grid = NULL;
+    if ((grid = malloc(sizeof(*grid))) == NULL) {
+        return NULL;
+    }
+    if (size == 0) {
+        size = 1;
+    }
+    grid->size = size;
+    grid->width = width;
+    grid->height = height;
+    grid->cols = NULL;
+    grid->rows = NULL;
+    grid->jump_matrix = NULL;
+
+    if ((grid->cols = alloc_cell_link(size, width)) == NULL) {
+        grid_free(grid);
+        return NULL;
+    }
+    if ((grid->rows = alloc_cell_link(size, height)) == NULL) {
+        grid_free(grid);
+        return NULL;
+    }
+    if ((grid->jump_matrix = alloc_jump_matrix(size)) == NULL) {
+        grid_free(grid);
+        return NULL;
+    }
+
+    return grid;
+}
+
+/* grid_free frees the memory allocated by Grid  */
+void grid_free(Grid * grid)
+{
+    if (grid == NULL) {
+        return;
+    }
+    if (grid->cols != NULL) {
+        free_cell_link(grid->cols);
+    }
+    if (grid->rows != NULL) {
+        free_cell_link(grid->rows);
+    }
+    if (grid->jump_matrix != NULL) {
+        free(grid->jump_matrix);
+    }
+    free(grid);
+}
+
+/* grid_clear clears the CellLinks and JumpMatrix to "start state" */
+void grid_clear(Grid * self)
+{
+    if (self == NULL) {
+        return;
+    }
+    self->cols->end_pos = self->width;
+    clear_cell_link(self->cols);
+    self->rows->end_pos = self->height;
+    clear_cell_link(self->rows);
+    self->jump_matrix[0][0] = NULL;
+}
+
+/* grid_split will split the grid by cutting a column and a row in two
+   in such a way that the region `reg` will fit the grid */
+void grid_split(Grid * self, Region * reg)
+{
+    size_t src_i, dest_i;
+    Cell *r_cell = NULL;
+    Cell *c_cell = NULL;
+    Cell *jump_target = NULL;
+    assert(reg->row_end_pos <= reg->row_cell->end_pos);
+    assert(reg->col_end_pos <= reg->col_cell->end_pos);
+
+    if (reg->row_end_pos < reg->row_cell->end_pos) {
+        cut(self->rows, reg->row_cell, reg->row_end_pos, &src_i, &dest_i);
+        copy_row(self->jump_matrix, src_i, dest_i, self->cols->jump_index);
+    }
+
+    if (reg->col_end_pos < reg->col_cell->end_pos) {
+        cut(self->cols, reg->col_cell, reg->col_end_pos, &src_i, &dest_i);
+        copy_col(self->jump_matrix, src_i, dest_i, self->rows->jump_index);
+    }
+
+    /* Compute jump_target */
+    if (reg->row_cell->next == NULL) {
+        assert(reg->row_cell->end_pos == self->height);
+        jump_target = COL_FULL;
+    } else {
+        jump_target = reg->row_cell->next;
+    }
+
+    for (r_cell = reg->row_cell_start; r_cell != NULL;
+         r_cell = r_cell->next) {
+        assert(self->jump_matrix[r_cell->jump_index]
+               [reg->col_cell_start->jump_index] == NULL);
+        self->jump_matrix[r_cell->jump_index][reg->
+                                              col_cell_start->jump_index] =
+            jump_target;
+        if (r_cell == reg->row_cell) {
+            break;
+        }
+    }
+
+    if (reg->col_cell_start == reg->col_cell) {
+        return;
+    }
+
+    for (c_cell = reg->col_cell_start->next; c_cell != NULL;
+         c_cell = c_cell->next) {
+        assert(self->jump_matrix[reg->row_cell_start->jump_index]
+               [c_cell->jump_index] == NULL);
+        self->jump_matrix[reg->row_cell_start->
+                          jump_index][c_cell->jump_index] = jump_target;
+        if (c_cell == reg->col_cell) {
+            break;
+        }
+    }
+    return;
+}
+
+/* grid_find_region searches the grid for a free space that can
+   contain the region `reg`. */
+int grid_find_region(Grid * grid, Rectangle * rectangle, Region * reg)
+{
+    long rec_col_end_pos, rec_row_end_pos;
+    long delta = rectangle->height;
+    long tmp;
+    Cell *col_cell_start = NULL;
+    Cell *col_cell = NULL;
+    Cell *row_cell_start = NULL;
+    Cell *row_cell = NULL;
+
+    Cell *jump_first = NULL;
+    Cell *jump_target = NULL;
+
+    /* Loop over columns */
+    rec_col_end_pos = rectangle->width;
+    col_cell_start = grid->cols->head;
+    while (col_cell_start != NULL) {
+
+        /* Loop over rows */
+        rec_row_end_pos = rectangle->height;
+        row_cell_start = row_cell = grid->rows->head;
+        jump_first = NULL;
+        while (row_cell_start != NULL) {
+
+            /* Check if cell is free. The cell is free if the
+               jump_matrix element is NULL. If not NULL, it is a
+               pointer to the next row cell to test. This is an
+               optimization to prevent checking cells we already know
+               are not free.  */
+            jump_target =
+                grid->jump_matrix[row_cell->
+                                  jump_index][col_cell_start->jump_index];
+
+            if (jump_target != NULL) {
+                if (jump_first == NULL) {
+                    jump_first = row_cell;
+                } else {
+                    /* This is an optimization to make bigger jumps */
+                    grid->jump_matrix[jump_first->jump_index]
+                        [col_cell_start->jump_index] = jump_target;
+                }
+            }
+
+            /* Column full. Abort this column. */
+            if (jump_target == COL_FULL) {
+                break;
+            }
+
+            /* Normal jump */
+            if (jump_target != NULL) {
+                row_cell = row_cell_start = jump_target;
+                rec_row_end_pos =
+                    row_cell->prev->end_pos + rectangle->height;
+                continue;
+            }
+
+            /* Free slot. Reset jump_first. */
+            jump_first = NULL;
+
+            /* Rectangle hight still doesn't fit; continue search */
+            if (row_cell->end_pos < rec_row_end_pos) {
+                row_cell = row_cell->next;
+                if (row_cell == NULL) {
+                    /* No more rows. Abort. */
+                    if ((tmp = rec_row_end_pos - grid->height) < delta) {
+                        delta = tmp;
+                    }
+                    break;
+                }
+                continue;
+            }
+
+            /* Free row-range found. Now we need to search column-wise
+               to check if free space is available in that direction
+               as well. */
+            col_cell = col_cell_start;
+            while (col_cell != NULL) {
+                jump_target =
+                    grid->
+                    jump_matrix[row_cell_start->jump_index][col_cell->
+                                                            jump_index];
+                if (jump_target != NULL) {
+                    break;
+                }
+                if (rec_col_end_pos <= col_cell->end_pos) {
+                    /* Free region found */
+                    reg->row_cell_start = row_cell_start;
+                    reg->row_cell = row_cell;
+                    reg->row_end_pos = rec_row_end_pos;
+                    reg->col_cell_start = col_cell_start;
+                    reg->col_cell = col_cell;
+                    reg->col_end_pos = rec_col_end_pos;
+                    return delta;
+                }
+                col_cell = col_cell->next;
+            }
+            /* Todo: Consider removing this break to continue the
+               search further down the row. */
+            break;
+        }
+
+        /* Prepare new iteration */
+        rec_col_end_pos = col_cell_start->end_pos + rectangle->width;
+        col_cell_start = col_cell_start->next;
+
+        /* Too wide to fit in any remaining columns. Abort. */
+        if (rec_col_end_pos > grid->width) {
+            break;
+        }
+    }
+    /* Failure! Couldn't find a free region. */
+    reg->col_cell = NULL;       /* Used as fail signal */
+    return delta;
+}
+
+/* grid_search_bbox will search for a bbox with smallest area that can
+   contain all the rectangles, `sizes`, in the `grid`. The bounding
+   box must also satisfy the bounding box restrictions `bbr`. */
+long
+grid_search_bbox(Grid * grid, Rectangle * sizes, BBoxRestrictions * bbr)
+{
+    size_t i = 0;
+    long happy_area = 1;        /* Todo */
+    long start_width, start_area, area, best_h, best_w, delta, d, grid_w;
+    Region reg;
+
+    grid->height = bbr->min_height;
+    grid->width = bbr->max_area / grid->height;
+    if (bbr->max_width < grid->width) {
+        grid->width = bbr->max_width;
+    }
+    start_width = grid->width;
+
+    start_area = area = bbr->max_area - 1;
+    best_w = grid->width;
+    best_h = grid->height;
+
+    while (grid->height <= bbr->max_height
+           && bbr->min_width <= grid->width) {
+        grid_clear(grid);
+        delta = bbr->max_height;
+        grid_w = 0;
+        /* Find position for all rectangles */
+        for (i = 0; i < grid->size - 1; i++) {
+            d = grid_find_region(grid, &sizes[i], &reg);
+            if (d < delta) {
+                delta = d;
+            }
+            /* Break if failure */
+            if (reg.col_cell == NULL) {
+                break;
+            }
+            /* Keep track of current grid width */
+            if (grid_w < reg.col_end_pos) {
+                grid_w = reg.col_end_pos;
+            }
+            assert(grid_w <= grid->width);
+            grid_split(grid, &reg);
+        }
+        /* All rectangles successfully packed? Update area. */
+        if (reg.col_cell != NULL) {
+            best_h = grid->height;
+            best_w = grid_w;
+            assert(best_h * best_w < area);
+            area = best_h * best_w;
+            assert(area <= bbr->max_area);
+            if (area <= happy_area) {
+                /* We have found a solution the caller is happy
+                   with. End search. */
+                goto done;
+            }
+        }
+
+        /* Inc height */
+        grid->height += delta;
+
+        /* Dec width limit */
+        grid->width = area / grid->height;
+	if (grid->width > bbr->max_width) {
+	    grid->width = bbr->max_width;
+	}
+        if (grid->width * grid->height == area) {
+            grid->width -= 1;
+        }
+        assert(grid->width * grid->height < area);
+    }
+
+    /* If the area hasn't changed from the start it means that we
+       never found a successful packing in the while loop. We set the
+       grid maximum with/height and return a negative value to
+       indicate failure. */
+    if (start_area == area) {
+        grid->width = start_width;
+        grid->height = bbr->min_height;
+        return -1;
+    }
+    /* Success */
+  done:grid->width = best_w;
+    grid->height = best_h;
+    return best_h;
+}
+
+/* ==========
+ * TEST CASES
+ * ==========
+ */
+#ifndef NDEBUG
+
+static void test_cell_link(void)
+{
+    CellLink *cl = NULL;
+    cl = alloc_cell_link(100, 1234);
+    assert(cl != NULL);
+
+    assert(cl->size == 100);
+    assert(cl->end_pos == 1234);
+    assert(cl->jump_index == 1);
+    assert(cl->head == &cl->cells[0]);
+    assert(cl->head->prev == NULL);
+    assert(cl->head->next == NULL);
+    assert(cl->head->end_pos == cl->end_pos);
+
+    free_cell_link(cl);
+}
+
+static void test_cell_link_cut(void)
+{
+    CellLink *cl = NULL;
+    cl = alloc_cell_link(100, 1000);
+    assert(cl != NULL);
+
+    size_t src_i, dest_i;
+    cut(cl, cl->head, 111, &src_i, &dest_i);
+
+    assert(cl->size == 100);
+    assert(cl->end_pos == 1000);
+    assert(cl->jump_index == 2);
+    assert(cl->head == &cl->cells[0]);
+    assert(cl->head->prev == NULL);
+    assert(cl->head->next == &cl->cells[1]);
+    assert(cl->head->end_pos == 111);
+
+    assert(src_i == 0);
+    assert(dest_i == 1);
+
+    assert(cl->cells[1].prev == cl->head);
+    assert(cl->cells[1].end_pos == 1000);
+
+    cut(cl, cl->head, 11, &src_i, &dest_i);
+
+    assert(src_i == 0);
+    assert(dest_i == 2);
+    assert(cl->head->end_pos == 11);
+    assert(cl->head->next->jump_index == 2);
+    assert(start_pos(cl->head->next) == 11);
+
+    clear_cell_link(cl);
+    assert(cl->jump_index == 1);
+
+    free_cell_link(cl);
+}
+
+static void test_jump_matrix(void)
+{
+    Cell *cell = NULL;
+    JumpMatrix jm = NULL;
+    size_t i, j, size;
+
+    size = 100;
+    jm = alloc_jump_matrix(size);
+    assert(jm != NULL);
+    assert(jm[0][0] == NULL);
+
+    for (i = 0; i < size; i++) {
+        for (j = 0; j < size; j++) {
+            jm[i][j] = cell;
+        }
+    }
+
+    free(jm);
+}
+
+static void test_jump_matrix_copy(void)
+{
+    JumpMatrix jm = NULL;
+    size_t i, j, size;
+
+    size = 2;
+    jm = alloc_jump_matrix(size);
+    assert(jm != NULL);
+    assert(jm[0][0] == NULL);
+
+    copy_row(jm, 0, 1, 1);
+    copy_col(jm, 0, 1, 2);
+
+    for (i = 0; i < size; i++) {
+        for (j = 0; j < size; j++) {
+            assert(jm[i][j] == NULL);
+        }
+    }
+
+    free(jm);
+}
+
+static void test_grid(void)
+{
+    Grid *grid = NULL;
+    grid = grid_alloc(100, 120, 50);
+    assert(grid != NULL);
+    assert(grid->size == 100);
+    assert(grid->width == 120);
+    assert(grid->height == 50);
+    assert(grid->cols != NULL);
+    assert(grid->rows != NULL);
+    assert(grid->jump_matrix != NULL);
+    grid_free(grid);
+}
+
+static void test_grid_split(void)
+{
+    Grid *grid = NULL;
+    Region reg;
+    grid = grid_alloc(100, 120, 50);
+    assert(grid != NULL);
+
+    reg.row_cell_start = reg.row_cell = grid->rows->head;
+    reg.row_end_pos = 30;
+    reg.col_cell_start = reg.col_cell = grid->cols->head;
+    reg.col_end_pos = 30;
+    grid_split(grid, &reg);
+
+    assert(grid->rows->head->end_pos == 30);
+    assert(grid->cols->head->end_pos == 30);
+    assert(grid->rows->head->next->end_pos == 50);
+    assert(grid->cols->head->next->end_pos == 120);
+
+    Cell _cell;
+    Cell *test_cell = &_cell;
+    grid->jump_matrix[0][0] = test_cell;
+
+    reg.row_cell_start = reg.row_cell = grid->rows->head->next;
+    reg.row_end_pos = 40;
+    reg.col_cell_start = reg.col_cell = grid->cols->head;
+    reg.col_end_pos = 10;
+    grid_split(grid, &reg);
+
+    assert(grid->jump_matrix[0][0] == test_cell);
+    assert(grid->jump_matrix[0][1] == NULL);
+    assert(grid->jump_matrix[0][2] == test_cell);
+
+    assert(grid->jump_matrix[1][0] == grid->rows->head->next->next);
+    assert(grid->jump_matrix[1][1] == NULL);
+    assert(grid->jump_matrix[1][2] == NULL);
+
+    assert(grid->jump_matrix[2][0] == NULL);
+    assert(grid->jump_matrix[2][1] == NULL);
+    assert(grid->jump_matrix[2][2] == NULL);
+
+    grid_free(grid);
+}
+
+int main(void)
+{
+    test_cell_link();
+    test_cell_link_cut();
+    printf("CELL LINK: PASSED\n");
+    test_jump_matrix();
+    test_jump_matrix_copy();
+    printf("JUMP MATRIX: PASSED\n");
+    test_grid();
+    test_grid_split();
+    printf("GRID: PASSED\n");
+    return 0;
+}
+#endif

--- a/minorminer/layout/layout.py
+++ b/minorminer/layout/layout.py
@@ -19,7 +19,7 @@ import networkx as nx
 import numpy as np
 from scipy import optimize, spatial
 from math import ceil
-import rpack
+from minorminer._extern import rpack
 
 def p_norm(G, p=2, starting_layout=None, G_distances=None, dim=None, center=None, scale=None, **kwargs):
     """Embeds graph ``G`` in :math:`R^d` with the p-norm and minimizes a 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ dwave-networkx>=0.8.11
 fasteners==0.15
 homebase==1.0.1
 Cython==3.0.6
-rectangle-packer==2.0.1

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,8 @@ class build_ext_compiler_check(build_ext):
 
         for ext in self.extensions:
             arg_key = ext.extra_compile_args
-            ext.extra_compile_args = extra_compile_args[arg_key][compiler]
+            if arg_key:
+                ext.extra_compile_args = extra_compile_args[arg_key][compiler]
 
         link_args = extra_link_args[compiler]
         for ext in self.extensions:
@@ -83,6 +84,7 @@ class Extension(extension.Extension, object):
 
 
 ext = '.pyx' if USE_CYTHON else '.cpp'
+ext_c = '.pyx' if USE_CYTHON else '.c'
 
 glasgow_cc = [
     '/'.join(['external/glasgow-subgraph-solver/src', f])
@@ -132,6 +134,12 @@ extensions = [
         language='c++',
         extra_compile_args = 'glasgow',
     ),
+    Extension(
+        name="minorminer._extern.rpack._core",
+        sources=["./minorminer/_extern/rpack/_core" + ext_c, "./minorminer/_extern/rpack/src/rpackcore.c"],
+        include_dirs=["./minorminer/_extern/rpack/include"],
+        language='c',
+    ),
 ]
 
 if USE_CYTHON:
@@ -155,8 +163,6 @@ install_requires = [
     "homebase>=1.0.1",
     "networkx>=2.4",
     "numpy>=1.21.6",
-    'rectangle-packer==2.0.1;python_version<"3.9"',  # 2.0.1+ does not support Python 3.8
-    'rectangle-packer>=2.0.1;python_version>="3.9"',
     "scipy>=1.7.3",
 ]
 
@@ -173,9 +179,12 @@ setup(
     packages=['minorminer',
               'minorminer.layout',
               'minorminer.utils',
+              'minorminer._extern.rpack',
               ],
     classifiers=classifiers,
     python_requires=python_requires,
     install_requires=install_requires,
-    cmdclass={'build_ext': build_ext_compiler_check}
+    cmdclass={'build_ext': build_ext_compiler_check},
+    package_data={"minorminer._extern.rpack._core": ["_core.pyx"]},
+    include_package_data=True,
 )


### PR DESCRIPTION
- Adds rectangle-packer as a submodule to minorminer
- Removes the rectangle-packer requirement from `requirements.txt`

> [!NOTE] 
> First attempted to add [rectangle-packer](https://github.com/Penlect/rectangle-packer) as a submodule to the [external](https://github.com/dwavesystems/minorminer/tree/main/external) folder, but the build failed due to required `.pyx`/`.pxd` files not being found in path (see [here](https://groups.google.com/g/cython-users/c/ILEwFY1FZBs) for details). It seems like the extension name in `setup.py` is required to follow the folder structure, which causes compilation issues when the `.pyx`/`.pxd` files are outside the `minorminer` source package folder.