### PR TITLE
Layout bug fix

### DIFF
--- a/minorminer/_minorminer.pyx
+++ b/minorminer/_minorminer.pyx
@@ -723,4 +723,7 @@ cdef _read_graph(input_graph &g, E):
             g.push_back(i, i)
     return L
 
-__all__ = ["find_embedding", "VARORDER", "miner"]
+def _mahdieh_delete_this():
+    print("hello")
+
+__all__ = ["find_embedding", "VARORDER", "miner", "_mahdieh_delete_this"]

--- a/minorminer/_minorminer.pyx
+++ b/minorminer/_minorminer.pyx
@@ -723,7 +723,4 @@ cdef _read_graph(input_graph &g, E):
             g.push_back(i, i)
     return L
 
-def _mahdieh_delete_this():
-    print("hello")
-
-__all__ = ["find_embedding", "VARORDER", "miner", "_mahdieh_delete_this"]
+__all__ = ["find_embedding", "VARORDER", "miner"]

--- a/minorminer/layout/__init__.py
+++ b/minorminer/layout/__init__.py
@@ -17,8 +17,8 @@ import time
 import networkx as nx
 import minorminer as mm
 
-from layout import Layout, dnx_layout, p_norm
-from placement import Placement, closest, intersection
+from .layout import Layout, dnx_layout, p_norm
+from .placement import Placement, closest, intersection
 
 
 def find_embedding(

--- a/minorminer/layout/__init__.py
+++ b/minorminer/layout/__init__.py
@@ -17,8 +17,8 @@ import time
 import networkx as nx
 import minorminer as mm
 
-from .layout import Layout, dnx_layout, p_norm
-from .placement import Placement, closest, intersection
+from layout import Layout, dnx_layout, p_norm
+from placement import Placement, closest, intersection
 
 
 def find_embedding(
@@ -179,3 +179,4 @@ def _parse_layout_parameter(S, T, layout, layout_kwargs):
             T_layout = Layout(T, layout=t_layout, **layout_kwargs)
 
     return S_layout, T_layout
+

--- a/minorminer/layout/layout.py
+++ b/minorminer/layout/layout.py
@@ -305,18 +305,19 @@ def dnx_layout(G, dim=None, center=None, scale=None, **kwargs):
     elif family == "zephyr":
         dnx_layout = dnx.zephyr_layout(
             G, dim=dim, center=dnx_center, scale=dnx_scale)
-        
+    
+    # if the output of dnx_layout is not what it should be (at the moment there is a bug in dnx.zephyr_layout and dnx.pegasus_layout)    
     dnx_layout_arr = np.array([(dnx_layout[v]-dnx_center)[:2] for v in G.nodes()]) #first two coordinates of layout-dnx_center
     x_min, y_min = np.min(dnx_layout_arr, axis=0)
     x_max, y_max = np.max(dnx_layout_arr, axis=0)
-    if x_min!=0 or x_max!=dnx_scale or y_min!=-dnx_scale or y_max!=0: # if the output of dnx_layout is not what it should be (at the moment there is a bug in dnx.zephyr_layout and dnx.pegasus_layout)
+    if x_min!=0 or x_max!=dnx_scale or y_min!=-dnx_scale or y_max!=0: 
         dnx_layout_arr = dnx_layout_arr - np.array([x_min, y_max]) #make (0, 0) top left corner
         dnx_layout_arr = dnx_layout_arr * np.array([(dnx_scale)/(x_max-x_min), (dnx_scale)/(y_max-y_min)]) #make (dnx_scale, -dnx_scale) bottom right corner
         paddim = dim - 2
         zeros = np.zeros((dnx_layout_arr.shape[0], paddim))
         dnx_layout_arr = np.hstack((dnx_layout_arr, zeros)) + dnx_center
         dnx_layout = {v: dnx_layout_arr[i] for i, v in enumerate(G.nodes())}
-
+    
     layout = Layout(G, dnx_layout)
     return layout.layout
 
@@ -715,7 +716,7 @@ def _rotate_to_minimize_area(points):
     best_idx = np.argmin(areas)
 
     # return the best rotation and its dimensions
-    points = np.dot(rotations[best_idx], points.T)
+    points = np.dot(rotations[best_idx], points.T).T
     min_y = np.nanmin(points[:, 0])
     max_y = np.nanmax(points[:, 0])
     min_x = np.nanmin(points[:, 1])

--- a/minorminer/layout/layout.py
+++ b/minorminer/layout/layout.py
@@ -333,7 +333,7 @@ def _nx_to_dnx_layout(center, scale):
             float: A scale value that is twice the original scale.
     
     """
-    dnx_center = (center[0] - scale, ) + (center[1] + scale, ) + tuple(0 for _ in center[2:])
+    dnx_center = (center[0] - scale, ) + (center[1] + scale, ) + tuple(x for x in center[2:])
     dnx_scale = 2*scale
 
     return dnx_center, dnx_scale

--- a/minorminer/layout/layout.py
+++ b/minorminer/layout/layout.py
@@ -162,10 +162,10 @@ def _graph_distance_matrix(G,
         disconnected_distance = len(G)
 
     dist_list = [
-        (u, [V.get(v, disconnected_distance) for v in sorted(G)])
-         for u, V in nx.all_pairs_shortest_path_length(G)
-         ]
-    return(np.array([_[1] for _ in sorted(dist_list)]))
+        (u, [V.get(v, disconnected_distance) for v in G])
+            for u, V in nx.all_pairs_shortest_path_length(G)
+            ]
+    return np.array([u_dist for u, u_dist in dist_list])
 
 def _p_norm_objective(layout_vector, G_distances, dim, p):
     """Compute the sum of differences squared between the p-norm and the graph 
@@ -306,7 +306,8 @@ def dnx_layout(G, dim=None, center=None, scale=None, **kwargs):
         dnx_layout = dnx.zephyr_layout(
             G, dim=dim, center=dnx_center, scale=dnx_scale)
     
-    # if the output of dnx_layout is not what it should be (at the moment there is a bug in dnx.zephyr_layout and dnx.pegasus_layout)    
+    # if the output of dnx_layout is not what it should be (at the moment there is a bug in dnx.zephyr_layout and dnx.pegasus_layout)
+    # https://github.com/dwavesystems/dwave-networkx/issues/239    
     dnx_layout_arr = np.array([(dnx_layout[v]-dnx_center)[:2] for v in G.nodes()]) #first two coordinates of layout-dnx_center
     x_min, y_min = np.min(dnx_layout_arr, axis=0)
     x_max, y_max = np.max(dnx_layout_arr, axis=0)

--- a/minorminer/layout/layout.py
+++ b/minorminer/layout/layout.py
@@ -160,12 +160,12 @@ def _graph_distance_matrix(G,
 
     if disconnected_distance is None:
         disconnected_distance = len(G)
+        
+    return np.array([
+        [V.get(v, disconnected_distance) for v in G]
+        for _, V in nx.all_pairs_shortest_path_length(G)
+        ])
 
-    dist_list = [
-        (u, [V.get(v, disconnected_distance) for v in G])
-            for u, V in nx.all_pairs_shortest_path_length(G)
-            ]
-    return np.array([u_dist for u, u_dist in dist_list])
 
 def _p_norm_objective(layout_vector, G_distances, dim, p):
     """Compute the sum of differences squared between the p-norm and the graph 

--- a/minorminer/layout/placement.py
+++ b/minorminer/layout/placement.py
@@ -20,8 +20,8 @@ import dwave_networkx as dnx
 import numpy as np
 from scipy import spatial
 
-from . import layout
-
+#from . import layout #MM-removed
+import layout #MM-added
 
 def intersection(S_layout, T_layout, **kwargs):
     """Map each vertex of S to its nearest row/column intersection qubit in T 
@@ -395,14 +395,17 @@ def _get_connected_subgraphs(G, k, single_set=False):
 
 def _minimize_overlap(distances, v_indices, T_subset_lookup, layout_points, overlap_counter):
     """A greedy penalty-type model for choosing nonoverlapping chains."""
-    subsets = {}
-    for i, d in zip(v_indices, distances):
-        subset = T_subset_lookup[layout_points[i]]
-        subsets[subset] = d + sum(10**overlap_counter[v] for v in subset)
-
-    cheapest_subset = min(subsets, key=subsets.get)
-    overlap_counter.update(cheapest_subset)
-    return cheapest_subset
+    for base in range(10, 0, -1):
+        try:    
+            subsets = {}
+            for i, d in zip(v_indices, distances):
+                subset = T_subset_lookup[layout_points[i]]
+                subsets[subset] = d + sum(base**overlap_counter[v] for v in subset)
+            cheapest_subset = min(subsets, key=subsets.get)
+            overlap_counter.update(cheapest_subset)
+            return cheapest_subset
+        except OverflowError:
+            continue
 
 
 class Placement(abc.MutableMapping):

--- a/minorminer/layout/placement.py
+++ b/minorminer/layout/placement.py
@@ -20,8 +20,7 @@ import dwave_networkx as dnx
 import numpy as np
 from scipy import spatial
 
-#from . import layout #MM-removed
-import layout #MM-added
+from . import layout 
 
 def intersection(S_layout, T_layout, **kwargs):
     """Map each vertex of S to its nearest row/column intersection qubit in T 

--- a/tests/layout/test_find_embedding.py
+++ b/tests/layout/test_find_embedding.py
@@ -21,7 +21,7 @@ import numpy as np
 
 import minorminer.layout as mml
 
-from .common import TestLayoutPlacement
+from common import TestLayoutPlacement
 
 
 class TestFindEmb(TestLayoutPlacement):

--- a/tests/layout/test_find_embedding.py
+++ b/tests/layout/test_find_embedding.py
@@ -21,7 +21,7 @@ import numpy as np
 
 import minorminer.layout as mml
 
-from common import TestLayoutPlacement
+from .common import TestLayoutPlacement
 
 
 class TestFindEmb(TestLayoutPlacement):

--- a/tests/layout/test_layout.py
+++ b/tests/layout/test_layout.py
@@ -23,7 +23,7 @@ import numpy as np
 import minorminer.layout as mml
 from minorminer.layout.layout import (_center_layout, _dimension_layout,
                                       _scale_layout, _graph_distance_matrix)
-from common import TestLayoutPlacement
+from .common import TestLayoutPlacement
 
 
 class TestLayout(TestLayoutPlacement):

--- a/tests/layout/test_layout.py
+++ b/tests/layout/test_layout.py
@@ -22,8 +22,8 @@ import numpy as np
 
 import minorminer.layout as mml
 from minorminer.layout.layout import (_center_layout, _dimension_layout,
-                                      _scale_layout)
-from .common import TestLayoutPlacement
+                                      _scale_layout, _graph_distance_matrix)
+from common import TestLayoutPlacement
 
 
 class TestLayout(TestLayoutPlacement):
@@ -263,3 +263,10 @@ class TestLayout(TestLayoutPlacement):
 
         # Test __repr__
         self.assertEqual(repr(L), "{}")
+
+    def test_graph_distance_matrix(self):
+        G = nx.Graph()
+        G.add_nodes_from([2, 1, 3, 4])
+        G.add_edges_from([(2, 1), (1, 3), (4, 2)])
+        dist_mat = _graph_distance_matrix(G)
+        self.assertTrue(np.array_equal(dist_mat, dist_mat.T), "The graph distance matrix is not symmetric")

--- a/tests/layout/test_layout.py
+++ b/tests/layout/test_layout.py
@@ -22,7 +22,7 @@ import numpy as np
 
 import minorminer.layout as mml
 from minorminer.layout.layout import (_center_layout, _dimension_layout,
-                                      _scale_layout, _graph_distance_matrix)
+                                      _scale_layout, _graph_distance_matrix, dnx_layout)
 from .common import TestLayoutPlacement
 
 
@@ -270,3 +270,11 @@ class TestLayout(TestLayoutPlacement):
         G.add_edges_from([(2, 1), (1, 3), (4, 2)])
         dist_mat = _graph_distance_matrix(G)
         self.assertTrue(np.array_equal(dist_mat, dist_mat.T), "The graph distance matrix is not symmetric")
+        
+    def test_dnx_layout(self):
+        G = dnx.zephyr_graph(2)
+        scale=10
+        G_dnx_layout = dnx_layout(G, scale=scale)
+        G_dnx_layout_arr = np.array([G_dnx_layout[v] for v in G.nodes()])
+        self.assertTrue(np.all((G_dnx_layout_arr >= -scale) & (G_dnx_layout_arr <= scale)),
+                        msg=f"Values are not within [{-scale}, {scale}]^2")

--- a/tests/layout/test_placement.py
+++ b/tests/layout/test_placement.py
@@ -184,5 +184,3 @@ def test_minimize_overlap(): # To test whether an avoidable OverFlowError in _mi
     king = nx.Graph(grid_edges+diagonal_edges)
     T = dnx.zephyr_graph(15)
     mml.find_embedding(king, T, scale=1)
-    
-test_minimize_overlap()

--- a/tests/layout/test_placement.py
+++ b/tests/layout/test_placement.py
@@ -22,7 +22,7 @@ from minorminer.layout.placement import (_lookup_intersection_coordinates,
                                          _parse_layout,
                                          _minimize_overlap)
 
-from common import TestLayoutPlacement
+from .common import TestLayoutPlacement
 
 
 class TestPlacement(TestLayoutPlacement):

--- a/tests/layout/test_placement.py
+++ b/tests/layout/test_placement.py
@@ -17,7 +17,7 @@ import unittest
 
 import dwave_networkx as dnx
 import minorminer.layout as mml
-import networkx as nx
+import networkx as nx 
 from minorminer.layout.placement import (_lookup_intersection_coordinates,
                                          _parse_layout,
                                          _minimize_overlap)
@@ -176,7 +176,7 @@ def rando_placer(S_layout, T_layout):
     T_vertices = list(T_layout)
     return {v: [random.choice(T_vertices)] for v in S_layout}
 
-def test_minimize_overlap():
+def test_minimize_overlap(): # To test whether an avoidable OverFlowError in _minimize_overlap is skipped
     dim_a = 10
     dim_b = 55
     grid_edges = list(nx.grid_graph([dim_a, dim_b]).edges())
@@ -184,3 +184,5 @@ def test_minimize_overlap():
     king = nx.Graph(grid_edges+diagonal_edges)
     T = dnx.zephyr_graph(15)
     mml.find_embedding(king, T, scale=1)
+    
+test_minimize_overlap()

--- a/tests/layout/test_placement.py
+++ b/tests/layout/test_placement.py
@@ -17,7 +17,7 @@ import unittest
 
 import dwave_networkx as dnx
 import minorminer.layout as mml
-import networkx as nx 
+import networkx as nx
 from minorminer.layout.placement import (_lookup_intersection_coordinates,
                                          _parse_layout,
                                          _minimize_overlap)
@@ -169,7 +169,7 @@ class TestPlacement(TestLayoutPlacement):
         # Layout input failure
         self.assertRaises(TypeError, mml.Placement,
                           "not a layout", self.C_layout)
-        self.assertRaises(TypeError, _parse_layout, "not a layout")       
+        self.assertRaises(TypeError, _parse_layout, "not a layout")
 
 
 def rando_placer(S_layout, T_layout):

--- a/tests/layout/test_placement.py
+++ b/tests/layout/test_placement.py
@@ -19,9 +19,10 @@ import dwave_networkx as dnx
 import minorminer.layout as mml
 import networkx as nx
 from minorminer.layout.placement import (_lookup_intersection_coordinates,
-                                         _parse_layout)
+                                         _parse_layout,
+                                         _minimize_overlap)
 
-from .common import TestLayoutPlacement
+from common import TestLayoutPlacement
 
 
 class TestPlacement(TestLayoutPlacement):
@@ -168,9 +169,18 @@ class TestPlacement(TestLayoutPlacement):
         # Layout input failure
         self.assertRaises(TypeError, mml.Placement,
                           "not a layout", self.C_layout)
-        self.assertRaises(TypeError, _parse_layout, "not a layout")
+        self.assertRaises(TypeError, _parse_layout, "not a layout")       
 
 
 def rando_placer(S_layout, T_layout):
     T_vertices = list(T_layout)
     return {v: [random.choice(T_vertices)] for v in S_layout}
+
+def test_minimize_overlap():
+    dim_a = 10
+    dim_b = 55
+    grid_edges = list(nx.grid_graph([dim_a, dim_b]).edges())
+    diagonal_edges = [((i, j), (i+1, j+1)) for i in range(dim_b-1) for j in range(dim_a-1)] + [((i, j), (i-1, j+1)) for i in range(1, dim_b) for j in range(dim_a-1)]
+    king = nx.Graph(grid_edges+diagonal_edges)
+    T = dnx.zephyr_graph(15)
+    mml.find_embedding(king, T, scale=1)


### PR DESCRIPTION
In `layout.py`:

- `_graph_distance_matrix` is modified so that it consistently returns symmetric distance matrix.
- `dnx_layout` is ensured to behave as expected (at the moment it gives values out of range due to some bug in `dnx.zephyr_layout` and `dnx.pegasus_layout`).
- `_nx_to_dnx_layout` is modified so that it returns center[dim] on dimensions dim>=3.
- edges in`_rotate_to_minimize_area` is modified to contain all edges of the convex hull (used to miss one). In the same function, the returned value (points) is modified so that it actually returns the rotation[best_idx].points.

In `placement.py`:
- `_minimize_overlap` now avoids an avoidable OverFlowError

I've added a couple of tests to the test suite to detect these issues.

