### PR TITLE
Release 0.2.19

### DIFF
--- a/minorminer/__init__.py
+++ b/minorminer/__init__.py
@@ -16,4 +16,4 @@
 
 from minorminer.minorminer import miner, VARORDER, find_embedding
 
-__version__ = "0.2.18"
+__version__ = "0.2.19"


### PR DESCRIPTION
### New Features

- Allow lattice type and lattice dimensions to be passed as options for `find_sublattice_embeddings()`. See [\#266](https://github.com/dwavesystems/minorminer/pull/266).

### Bug Fixes

- Fix `find_sublattice_embeddings()` to not produce non-disjoint embeddings when `use_tile_embedding=True` is set. See [\#265](https://github.com/dwavesystems/minorminer/pull/265).
