### PR TITLE
Updating random number generation to not overflow

### DIFF
--- a/include/find_embedding/embedding_problem.hpp
+++ b/include/find_embedding/embedding_problem.hpp
@@ -237,7 +237,7 @@ class embedding_problem_base {
               num_r(n_r),
               qubit_nbrs(q_n),
               var_nbrs(v_n),
-              rand(0, 0xffffffff),
+              rand(0, std::numeric_limits<int>::max()),
               var_order_space(n_v),
               var_order_visited(n_v, 0),
               var_order_shuffle(n_v),

--- a/include/find_embedding/embedding_problem.hpp
+++ b/include/find_embedding/embedding_problem.hpp
@@ -212,8 +212,8 @@ class embedding_problem_base {
     //! Mutable references to qubit numbers and variable numbers
     vector<vector<int>> &qubit_nbrs, &var_nbrs;
 
-    //! distribution over [0, 0xffffffff]
-    uniform_int_distribution<> rand;
+    //! distribution over [0, std::numeric_limits<int>::max()]
+    uniform_int_distribution<int> rand;
 
     vector<int> var_order_space;
     vector<int> var_order_visited;


### PR DESCRIPTION
rand is a `std::uniform_int_distribution<>`, which defaults to `int`. So when it's called with `0xffffffff`, that is `-1`.

Not sure if the right fix is to change the integer type or the initialization.