### PR TITLE
Fix googletest testing

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -7,7 +7,7 @@ ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
   #GIT_TAG           master
   # Temporary: to avoid https://github.com/google/googletest/issues/2711
-  GIT_TAG           release-1.10.0
+  GIT_TAG           v1.16.0
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""

--- a/include/find_embedding/pairing_queue.hpp
+++ b/include/find_embedding/pairing_queue.hpp
@@ -41,10 +41,10 @@ class pairing_node : public N {
     pairing_node *desc;
 
   public:
-    pairing_node<N>() {}
+    pairing_node() {}
 
     template <class... Args>
-    pairing_node<N>(Args... args) : N(args...), next(nullptr), desc(nullptr) {}
+    pairing_node(Args... args) : N(args...), next(nullptr), desc(nullptr) {}
 
     //! the basic operation of the pairing queue -- put `this` and `other`
     //! into heap-order

--- a/include/find_embedding/util.hpp
+++ b/include/find_embedding/util.hpp
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <iterator>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <queue>
 #include <random>


### PR DESCRIPTION
Part of a fix for #269. Bumps the version of google test to avoid warnings (which are errors with -Werror), fix a missing dependency and resolve a c++20 incompatibility issue.

I'd prefer not to merge this without getting the tests running on circleci, but I'm not comfortable adding that without supervision.