### PR TITLE
Add keyboard interrupts for subgraph.find_subgraph

### DIFF
--- a/releasenotes/notes/glasgow-cancel-737ef7ebd8312635.yaml
+++ b/releasenotes/notes/glasgow-cancel-737ef7ebd8312635.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - add the ability to interrupt subgraph.find_subgraph with ctrl-c


### PR DESCRIPTION
I've finally figured out a (hopefully) good-enough means to halt on ctrl-c within `find_subgraph`.  Sadly, testing this capability in CI has proven flaky in the past (as seen in [tests/test_lib.py:841 ](https://github.com/dwavesystems/minorminer/blob/2d5ace1286592449c87c5e7694d8d172fc923c2e/tests/test_lib.py#L841)).  I'll try and scrounge some folks on windows and osx to do some tests.