### PR TITLE
Release 0.2.22

### DIFF
--- a/minorminer/__init__.py
+++ b/minorminer/__init__.py
@@ -16,4 +16,4 @@
 
 from minorminer.minorminer import miner, VARORDER, find_embedding
 
-__version__ = "0.2.21"
+__version__ = "0.2.22"


### PR DESCRIPTION
### Upgrade Notes

- Drop NumPy 1.x support.

<!-- -->

- Rename `minorminer.layout.dnx_layout` to
  `minorminer.layout.graph_layout` and deprecate it, but keep an alias
  for backwards compatibility.

### Bug Fixes

- Use `dwave-graphs` instead of the deprecated `dwave-networkx`.
